### PR TITLE
Revert to using proxy_protocol_addr for real ip

### DIFF
--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -143,17 +143,15 @@ http {
        ''                $server_port;
     }
 
-    {{ if $cfg.UseProxyProtocol }}
-    map $http_x_forwarded_for $the_real_ip {
-        default          $http_x_forwarded_for;
-        ''               $proxy_protocol_addr;
+    map $pass_access_scheme $the_x_forwarded_for {
+        default           $remote_addr;
+        https             $proxy_protocol_addr;
     }
-    {{ else }}
-    map $http_x_forwarded_for $the_real_ip {
-        default          $http_x_forwarded_for;
-        ''               $remote_addr;
+
+    map $pass_access_scheme $the_real_ip {
+        default           $remote_addr;
+        https             $proxy_protocol_addr;
     }
-    {{ end }}
 
     # map port 442 to 443 for header X-Forwarded-Port
     map $pass_server_port $pass_port {


### PR DESCRIPTION
## What?
- This is attempt at fixing the issue of not having access to the accurate client_id
- This reverts to the changes made to the nginx config regarding the real_ip logic from https://github.com/kubernetes/ingress/pull/890
- This does indeed fix the issue of real_ip - [demo](kt-cloud-test.shopifycloud.com) in staging

- I am not sure if we could get this merged upstream since this change was made to rectify another issue but this could provide us with a fix while I try to ping the maintainer and try and work towards a fix?

cc/ @n1koo @ibawt thoughts?