### PR TITLE
Introduce an upstream-hash-by annotation to support consistent hashing by nginx variable

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-0.9.0-beta.11-shopify
+0.9.0-beta.12-shopify

--- a/controllers/nginx/configuration.md
+++ b/controllers/nginx/configuration.md
@@ -5,6 +5,7 @@
 * [Custom NGINX template](#custom-nginx-template)
 * [Annotations](#annotations)
 * [Custom NGINX upstream checks](#custom-nginx-upstream-checks)
+* [Custom NGINX upstream hashing](#custom-nginx-upstream-hashing)
 * [Authentication](#authentication)
 * [Rewrite](#rewrite)
 * [Rate limiting](#rate-limiting)
@@ -63,6 +64,7 @@ The following annotations are supported:
 |[ingress.kubernetes.io/ssl-redirect](#server-side-https-enforcement-through-redirect)|true or false|
 |[ingress.kubernetes.io/upstream-max-fails](#custom-nginx-upstream-checks)|number|
 |[ingress.kubernetes.io/upstream-fail-timeout](#custom-nginx-upstream-checks)|number|
+|[ingress.kubernetes.io/upstream-hash-by](#custom-nginx-upstream-hashing)|string|
 |[ingress.kubernetes.io/whitelist-source-range](#whitelist-source-range)|CIDR|
 |[ingress.kubernetes.io/server-alias](#server-alias)|string|
 |[ingress.kubernetes.io/client-body-buffer-size](#client-body-buffer-size)|string|
@@ -105,6 +107,14 @@ In NGINX, backend server pools are called "[upstreams](http://nginx.org/en/docs/
 **Important:** All Ingress rules using the same service will use the same upstream. Only one of the Ingress rules should define annotations to configure the upstream servers.
 
 Please check the [custom upstream check](../../examples/customization/custom-upstream-check/README.md) example.
+
+### Custom NGINX upstream hashing
+
+NGINX supports load balancing by client-server mapping based on [consistent hashing](http://nginx.org/en/docs/http/ngx_http_upstream_module.html#hash) for a given key. The key can contain text, variables or any combination thereof. This feature allows for request stickiness other than client IP or cookies. The [ketama](http://www.last.fm/user/RJ/journal/2007/04/10/392555/) consistent hashing method will be used which ensures only a few keys would be remapped to different servers on upstream group changes.
+
+To enable consistent hashing for a backend:
+
+`ingress.kubernetes.io/upstream-hash-by`: the nginx variable, text value or any combination thereof to use for consistent hashing. For example `ingress.kubernetes.io/upstream-hash-by: "$request_uri"` to consistently hash upstream requests by the current request URI.
 
 ### Authentication
 

--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -264,6 +264,10 @@ http {
         {{ $cfg.LoadBalanceAlgorithm }};
         {{ end }}
 
+        {{ if $upstream.UpstreamHashBy }}
+        hash {{ $upstream.UpstreamHashBy }} consistent;
+        {{ end }}
+
         {{ if (gt $cfg.UpstreamKeepaliveConnections 0) }}
         keepalive {{ $cfg.UpstreamKeepaliveConnections }};
         {{ end }}

--- a/controllers/nginx/test/data/config.json
+++ b/controllers/nginx/test/data/config.json
@@ -11,6 +11,7 @@
 			"ssl-redirect": true,
 			"upstream-fail-timeout": 0,
 			"upstream-max-fails": 0,
+			"upstream-hash-by": "$request_uri",
 			"whitelist-source-range": null
 		},
 		"bodySize": "1m",

--- a/core/pkg/ingress/annotations/upstreamhashby/main.go
+++ b/core/pkg/ingress/annotations/upstreamhashby/main.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package upstreamhashby
+
+import (
+	extensions "k8s.io/api/extensions/v1beta1"
+
+	"k8s.io/ingress/core/pkg/ingress/annotations/parser"
+)
+
+const (
+	annotation = "ingress.kubernetes.io/upstream-hash-by"
+)
+
+type upstreamhashby struct {
+}
+
+// NewParser creates a new CORS annotation parser
+func NewParser() parser.IngressAnnotation {
+	return annotation{}
+}
+
+// Parse parses the annotations contained in the ingress rule
+// used to indicate if the location/s contains a fragment of
+// configuration to be included inside the paths of the rules
+func (a upstreamhashby) Parse(ing *extensions.Ingress) (interface{}, error) {
+	return parser.GetStringAnnotation(annotation, ing)
+}

--- a/core/pkg/ingress/annotations/upstreamhashby/main_test.go
+++ b/core/pkg/ingress/annotations/upstreamhashby/main_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package upstreamhashby
+
+import (
+	"testing"
+
+	api "k8s.io/api/core/v1"
+	extensions "k8s.io/api/extensions/v1beta1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestParse(t *testing.T) {
+	ap := NewParser()
+	if ap == nil {
+		t.Fatalf("expected a parser.IngressAnnotation but returned nil")
+	}
+
+	testCases := []struct {
+		annotations map[string]string
+		expected    string
+	}{
+		{map[string]string{annotation: "$request_uri"}, "$request_uri"},
+		{map[string]string{annotation: "false"}, "false"},
+		{map[string]string{}, ""},
+		{nil, ""},
+	}
+
+	ing := &extensions.Ingress{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      "foo",
+			Namespace: api.NamespaceDefault,
+		},
+		Spec: extensions.IngressSpec{},
+	}
+
+	for _, testCase := range testCases {
+		ing.SetAnnotations(testCase.annotations)
+		result, _ := ap.Parse(ing)
+		if result != testCase.expected {
+			t.Errorf("expected %v but returned %v, annotations: %s", testCase.expected, result, testCase.annotations)
+		}
+	}
+}

--- a/core/pkg/ingress/defaults/main.go
+++ b/core/pkg/ingress/defaults/main.go
@@ -85,6 +85,12 @@ type Backend struct {
 	// Default: 0, ie use platform liveness probe
 	UpstreamFailTimeout int `json:"upstream-fail-timeout"`
 
+	// Enable stickiness by client-server mapping based on a NGINX variable, text or a combination of both.
+	// A consistent hashing method will be used which ensures only a few keys would be remapped to different
+	// servers on upstream group changes
+	// http://nginx.org/en/docs/http/ngx_http_upstream_module.html#hash
+	UpstreamHashBy string `json:"upstream-hash-by"`
+
 	// WhitelistSourceRange allows limiting access to certain client addresses
 	// http://nginx.org/en/docs/http/ngx_http_access_module.html
 	WhitelistSourceRange []string `json:"whitelist-source-range,-"`


### PR DESCRIPTION
Proof of concept for services that require stickiness through means other than cookies or client IP.

@n1koo @karanthukral @ElvinEfendi @ibawt @mkobetic 