### PR TITLE
Fix regressions from the initial pass of the upstream-hash-by annotation

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-0.9.0-beta.12-shopify
+0.9.0-beta.11-shopify-upstream-hash-by

--- a/core/pkg/ingress/annotations/upstreamhashby/main.go
+++ b/core/pkg/ingress/annotations/upstreamhashby/main.go
@@ -31,7 +31,7 @@ type upstreamhashby struct {
 
 // NewParser creates a new CORS annotation parser
 func NewParser() parser.IngressAnnotation {
-	return annotation{}
+	return upstreamhashby{}
 }
 
 // Parse parses the annotations contained in the ingress rule

--- a/core/pkg/ingress/controller/annotations.go
+++ b/core/pkg/ingress/controller/annotations.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/ingress/core/pkg/ingress/annotations/auth"
 	"k8s.io/ingress/core/pkg/ingress/annotations/authreq"
 	"k8s.io/ingress/core/pkg/ingress/annotations/authtls"
+	"k8s.io/ingress/core/pkg/ingress/annotations/clientbodybuffersize"
 	"k8s.io/ingress/core/pkg/ingress/annotations/cors"
 	"k8s.io/ingress/core/pkg/ingress/annotations/healthcheck"
 	"k8s.io/ingress/core/pkg/ingress/annotations/ipwhitelist"
@@ -37,9 +38,9 @@ import (
 	"k8s.io/ingress/core/pkg/ingress/annotations/sessionaffinity"
 	"k8s.io/ingress/core/pkg/ingress/annotations/snippet"
 	"k8s.io/ingress/core/pkg/ingress/annotations/sslpassthrough"
+	"k8s.io/ingress/core/pkg/ingress/annotations/upstreamhashby"
 	"k8s.io/ingress/core/pkg/ingress/errors"
 	"k8s.io/ingress/core/pkg/ingress/resolver"
-	"k8s.io/ingress/core/pkg/ingress/annotations/clientbodybuffersize"
 )
 
 type extractorConfig interface {
@@ -73,6 +74,7 @@ func newAnnotationExtractor(cfg extractorConfig) annotationExtractor {
 			"SessionAffinity":      sessionaffinity.NewParser(),
 			"SSLPassthrough":       sslpassthrough.NewParser(),
 			"ConfigurationSnippet": snippet.NewParser(),
+			"UpstreamHashBy":       upstreamhashby.NewParser(),
 			"Alias":                alias.NewParser(),
 			"ClientBodyBufferSize": clientbodybuffersize.NewParser(),
 		},
@@ -115,6 +117,7 @@ const (
 	serviceUpstream      = "ServiceUpstream"
 	serverAlias          = "Alias"
 	clientBodyBufferSize = "ClientBodyBufferSize"
+	upstreamHashBy       = "UpstreamHashBy"
 )
 
 func (e *annotationExtractor) ServiceUpstream(ing *extensions.Ingress) bool {
@@ -154,4 +157,9 @@ func (e *annotationExtractor) ClientBodyBufferSize(ing *extensions.Ingress) stri
 func (e *annotationExtractor) SessionAffinity(ing *extensions.Ingress) *sessionaffinity.AffinityConfig {
 	val, _ := e.annotations[sessionAffinity].Parse(ing)
 	return val.(*sessionaffinity.AffinityConfig)
+}
+
+func (e *annotationExtractor) UpstreamHashBy(ing *extensions.Ingress) string {
+	val, _ := e.annotations[upstreamHashBy].Parse(ing)
+	return val.(string)
 }

--- a/core/pkg/ingress/controller/controller.go
+++ b/core/pkg/ingress/controller/controller.go
@@ -813,6 +813,7 @@ func (ic *GenericController) createUpstreams(data []interface{}) map[string]*ing
 		secUpstream := ic.annotations.SecureUpstream(ing)
 		hz := ic.annotations.HealthCheck(ing)
 		serviceUpstream := ic.annotations.ServiceUpstream(ing)
+		upstreamHashBy := ic.annotations.UpstreamHashBy(ing)
 
 		var defBackend string
 		if ing.Spec.Backend != nil {
@@ -871,6 +872,10 @@ func (ic *GenericController) createUpstreams(data []interface{}) map[string]*ing
 
 				if upstreams[name].SecureCACert.Secret == "" {
 					upstreams[name].SecureCACert = secUpstream.CACert
+				}
+
+				if upstreams[name].UpstreamHashBy == "" {
+					upstreams[name].UpstreamHashBy = upstreamHashBy
 				}
 
 				svcKey := fmt.Sprintf("%v/%v", ing.GetNamespace(), path.Backend.ServiceName)

--- a/core/pkg/ingress/types.go
+++ b/core/pkg/ingress/types.go
@@ -165,6 +165,8 @@ type Backend struct {
 	Endpoints []Endpoint `json:"endpoints,omitempty"`
 	// StickySessionAffinitySession contains the StickyConfig object with stickness configuration
 	SessionAffinity SessionAffinityConfig `json:"sessionAffinityConfig"`
+	// Consistent hashing by NGINX variable
+	UpstreamHashBy string `json:"upstream-hash-by,omitempty"`
 }
 
 // SessionAffinityConfig describes different affinity configurations for new sessions.

--- a/core/pkg/ingress/types_equals.go
+++ b/core/pkg/ingress/types_equals.go
@@ -177,6 +177,9 @@ func (b1 *Backend) Equal(b2 *Backend) bool {
 	if !(&b1.SessionAffinity).Equal(&b2.SessionAffinity) {
 		return false
 	}
+	if b1.UpstreamHashBy != b2.UpstreamHashBy {
+		return false
+	}
 
 	if len(b1.Endpoints) != len(b2.Endpoints) {
 		return false

--- a/tests/manifests/configuration-a.json
+++ b/tests/manifests/configuration-a.json
@@ -31,6 +31,7 @@
 			}
 		},
 		"port": 0,
+		"upstream-hash-by": "$request_uri",
 		"secure": false,
 		"secureCert": {
 			"secret": "",


### PR DESCRIPTION
References this fallout from https://github.com/Shopify/ingress/pull/5:

```
E1003 11:49:02.768548       8 controller.go:428] unexpected failure restarting the backend: 
template: nginx.tmpl:267:23: executing "nginx.tmpl" at <$upstream.UpstreamHa...>: can't evaluate field UpstreamHashBy in type *ingress.Backend
```

I had to introduce special case handling for the `upstream-hash-by` annotation on backend creation as most of the annotations are scoped to the `Location` type and injected by means of the `mergeLocationAnnotations` utility helper.

🎩  : 

```
host:test user$ kubectl describe ing -n something-staging
Name:            something-web
Namespace:        something-staging
Address:        X.X.X.X
Default backend:    default-http-backend:80 (Y.Y.Y.Y:8080)
TLS:
  star-something terminates something-staging.something.com
Rules:
  Host                    Path    Backends
  ----                    ----    --------
  something-staging.something.com    
                             something-web:80 (<none>)
Annotations:
  auth-realm:        blah bblah
  auth-secret:        something-basic-auth
  auth-type:        basic
  upstream-hash-by:    $request_uri <<<<<<<<<<<<<<<<<<<<<<<<<<<
```

```
    upstream something-staging-something-web-80 {
        # Load balance algorithm; empty for round robin, which is the default
        least_conn;

        hash $request_uri consistent; <<<<<<<<<<<<<<<<<<<<
        server Y.Y.Y.Y:8000 max_fails=0 fail_timeout=0;
    }
```

Also reasoning regarding the version:

Previous version `0.9.0-beta.12-shopify` basically represents a new upstream version already available so I think this would work better: `0.9.0-beta.11-shopify-<latest-feature-added>`
then the version lines up with the last upstream version we're tracking
and hint @ the shopify fork and also the last feature added
eg. `0.9.0-beta.11-shopify-upstream-hash-by`

@ibawt @n1koo @mkobetic @karanthukral 