### PR TITLE
make sure http host is passed to upstream

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -226,6 +226,17 @@ http {
     }
     {{ end }}
 
+    # Obtain best http host
+    map $http_host $this_host {
+        default          $http_host;
+        ''               $host;
+    }
+
+    map $http_x_forwarded_host $best_http_host {
+        default          $http_x_forwarded_host;
+        ''               $this_host;
+    }
+
     {{ if $cfg.ComputeFullForwardedFor }}
     # We can't use $proxy_add_x_forwarded_for because the realip module
     # replaces the remote_addr too soon
@@ -714,7 +725,7 @@ stream {
 
                 return 497;
                 {{ else }}
-                return {{ $all.Cfg.HTTPRedirectCode }} https://$host$request_uri;
+                return {{ $all.Cfg.HTTPRedirectCode }} https://$best_http_host$request_uri;
                 {{ end }}
             }
             {{ end }}
@@ -784,7 +795,7 @@ stream {
             {{ if not (empty $location.UpstreamVhost) }}
             proxy_set_header Host                   "{{ $location.UpstreamVhost }}";
             {{ else }}
-            proxy_set_header Host                   $host;
+            proxy_set_header Host                   $best_http_host;
             {{ end }}
 
             # Pass the extracted client certificate to the backend
@@ -816,7 +827,7 @@ stream {
             {{ else }}
             proxy_set_header X-Forwarded-For        $the_real_ip;
             {{ end }}
-            proxy_set_header X-Forwarded-Host       $host;
+            proxy_set_header X-Forwarded-Host       $best_http_host;
             proxy_set_header X-Forwarded-Port       $pass_port;
             proxy_set_header X-Forwarded-Proto      $pass_access_scheme;
             proxy_set_header X-Original-URI         $request_uri;


### PR DESCRIPTION
Fixes the bug introduced at https://github.com/kubernetes/ingress-nginx/pull/1926. This is almost the revert of that PR except at https://github.com/Shopify/ingress/pull/9/files#diff-980db9e4b88704f12338bd074839f94eR724 I left `$host`. That way the issue that PR originally tried to fix still stays fixed.

@Shopify/edgescale @n1koo 