### PR TITLE
Nicer `pipa build` usage

### DIFF
--- a/.shopify-build/pipelines.yml
+++ b/.shopify-build/pipelines.yml
@@ -2,11 +2,11 @@ containers:
   production:
     environment: production
     build:
-      command: pipa build -x --push -- ./build.sh gcr.io/shopify-docker-images/apps/production/ingress:${BUILDKITE_COMMIT}
+      command: pipa build -x --push -- ./build.sh
   ci:
     environment: ci
     build:
-      command: pipa build -x --push -- ./build.sh gcr.io/shopify-docker-images/apps/ci/ingress:${BUILDKITE_COMMIT}
+      command: pipa build -x --push -- ./build.sh
 
 pipelines:
   nginx-ingress-controller-ci:

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 set -ex
 
-if [[ "$#" -ne 1 ]]; then
+DOCKER_TAG=${1:-$PIPA_IMAGE_FULL_NAME}
+
+if [[ -z "${DOCKER_TAG}" ]]; then
   echo "$0 [image]"
   exit 1
 fi
@@ -13,4 +15,4 @@ ARCH=amd64
 
 docker run -e CGO_ENABLED=0 -e GOOS=linux -e GOARCH=${ARCH} -v ${PWD}:/go/src/${PKG} -w /tmp/src golang:${GO_VERSION} go build -a -installsuffix cgo -ldflags "-s -w -X ${PKG}/version.RELEASE=${TAG} -X ${PKG}/version.COMMIT=${COMMIT} -X ${PKG}/version.REPO=${REPO_INFO}" -o /go/src/${PKG}/rootfs/nginx-ingress-controller ${PKG}/cmd/nginx
 
-docker build -t $1 .
+docker build -t "${DOCKER_TAG}" .


### PR DESCRIPTION
Follow up to #10, post-summit and with a clearer head I have a nicer solution to this problem -
reading `PIPA_IMAGE_FULL_NAME` directly in the script is much cleaner. @stefanmb I would like to update the Pipa docs to suggest this pattern, is that ok with you?