### PR TITLE
Buffered backends fix

### DIFF
--- a/rootfs/etc/nginx/lua/configuration.lua
+++ b/rootfs/etc/nginx/lua/configuration.lua
@@ -11,7 +11,7 @@ function _M.new_backends()
   ngx.req.read_body()
   local backends = ngx.req.get_body_data()
   if not backends then
-    -- response might be have been written to tmp file if size(body) > client_body_buffer_size
+    -- request body might've been wrote to tmp file if body > client_body_buffer_size
     local file_name = ngx.req.get_body_file()
     local file = assert(io.open(file_name, "rb"))
     backends = file:read("*all")
@@ -19,8 +19,7 @@ function _M.new_backends()
   end
 
   if not backends then
-    -- no current backends data found
-    ngx.log(ngx.ERR, "dynamic-configuration: empty response body")
+    ngx.log(ngx.ERR, "dynamic-configuration: empty request body")
     ngx.status = ngx.HTTP_BAD_REQUEST
     return
   end

--- a/rootfs/etc/nginx/lua/configuration.lua
+++ b/rootfs/etc/nginx/lua/configuration.lua
@@ -7,6 +7,27 @@ function _M.get_backends_data()
   return configuration_data:get("backends")
 end
 
+function _M.new_backends()
+  ngx.req.read_body()
+  local backends = ngx.req.get_body_data()
+  if not backends then
+    -- response might be have been written to tmp file if size(body) > client_body_buffer_size
+    local file_name = ngx.req.get_body_file()
+    local file = assert(io.open(file_name, "rb"))
+    backends = file:read("*all")
+    file:close()
+  end
+
+  if not backends then
+    -- no current backends data found
+    ngx.log(ngx.ERR, "configuration/backends: empty response body")
+    ngx.status = ngx.HTTP_BAD_REQUEST
+    return
+  end
+
+  return backends
+end
+
 function _M.call()
   if ngx.var.request_method ~= "POST" and ngx.var.request_method ~= "GET" then
     ngx.status = ngx.HTTP_BAD_REQUEST
@@ -26,20 +47,7 @@ function _M.call()
     return
   end
 
-  ngx.req.read_body()
-  local backends = ngx.req.get_body_data()
-  if not backends then
-    -- response might be have been written to tmp file if size(body) > client_body_buffer_size
-    backends = ngx.req.get_body_file()
-  end
-  if not backends then
-    -- no current backends data found
-    ngx.log(ngx.ERR, "configuration/backends: empty response body")
-    ngx.status = ngx.HTTP_BAD_REQUEST
-    return
-  end
-
-  local success, err = configuration_data:set("backends", ngx.req.get_body_data())
+  local success, err = configuration_data:set("backends", _M.new_backends())
   if not success then
     ngx.log(ngx.ERR, "configuration/backends: error updating configuration: " .. tostring(err))
     ngx.status = ngx.HTTP_BAD_REQUEST

--- a/rootfs/etc/nginx/lua/configuration.lua
+++ b/rootfs/etc/nginx/lua/configuration.lua
@@ -20,7 +20,7 @@ function _M.new_backends()
 
   if not backends then
     -- no current backends data found
-    ngx.log(ngx.ERR, "configuration/backends: empty response body")
+    ngx.log(ngx.ERR, "dynamic-configuration: empty response body")
     ngx.status = ngx.HTTP_BAD_REQUEST
     return
   end
@@ -49,7 +49,7 @@ function _M.call()
 
   local success, err = configuration_data:set("backends", _M.new_backends())
   if not success then
-    ngx.log(ngx.ERR, "configuration/backends: error updating configuration: " .. tostring(err))
+    ngx.log(ngx.ERR, "dynamic-configuration: error updating configuration: " .. tostring(err))
     ngx.status = ngx.HTTP_BAD_REQUEST
     return
   end

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -270,7 +270,7 @@ func UpdateDeployment(kubeClientSet kubernetes.Interface, namespace string, name
 		return err
 	}
 
-	err = WaitForPodsReady(kubeClientSet, 60*time.Second, replicas, namespace, metav1.ListOptions{
+	err = WaitForPodsReady(kubeClientSet, 90*time.Second, replicas, namespace, metav1.ListOptions{
 		LabelSelector: fields.SelectorFromSet(fields.Set(deployment.Spec.Template.ObjectMeta.Labels)).String(),
 	})
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
* Read from temp file if the request body from the controller's POST to update backends is larger than client_body_buffer_size.
* There was an to address this problem over here: https://github.com/kubernetes/ingress-nginx/pull/2309/files - but the updates will still silently fail by updating the lua shared table with `nil` if the controller POST body is larger than 10m. 
* This PR makes sure that the dictionary is **not updated** if there is either too large of a request body - or an empty request body.

**Which issue this PR fixes** 
* https://github.com/Shopify/edgescale/issues/398

**Special notes for your reviewer**:
* Could someone look at the test I've written? What I'm doing right now is updating the ingress-nginx controller's `client-body-buffer-size` to be set to `1k` so I can reproduce the problem. 
* After the test, the attribute is reset to the Nginx default - 8k. 🤔as I write this, I realize I can handle this better...

r/ @ElvinEfendi @zrdaley @fmejia97 