### PR TITLE
release latest version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,8 @@ jobs:
   # split builds to avoid job timeouts
   - stage: publish amd64
     if: type = push AND branch = master AND repo = Shopify/ingress
+    env:
+      - TAG=0.13.0-rc.1
     script:
     - travis_wait ${TRAVIS_TIMEOUT} .travis/publish.sh amd64
   - stage: publish arm


### PR DESCRIPTION
so that we can use it in our clusters without waiting upstream release

@Shopify/edgescale 