### PR TITLE
Add lua endpoint to handle certificates in dynamic configuration mode

### DIFF
--- a/build/test-lua.sh
+++ b/build/test-lua.sh
@@ -23,6 +23,7 @@ resty \
   -I /usr/local/lib/lua \
   -I /usr/lib/lua-platform-path/lua/5.1 \
   --shdict "configuration_data 5M" \
+  --shdict "certificate_data 16M" \
   --shdict "balancer_ewma 1M" \
   --shdict "balancer_ewma_last_touched_at 1M" \
   ./rootfs/etc/nginx/lua/test/run.lua ${BUSTED_ARGS} ./rootfs/etc/nginx/lua/test/

--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -196,8 +196,6 @@ func buildLuaSharedDictionaries(s interface{}, dynamicConfigurationEnabled bool,
 			"lua_shared_dict balancer_ewma 1M",
 			"lua_shared_dict balancer_ewma_last_touched_at 1M",
 			"lua_shared_dict sticky_sessions 1M",
-			"lua_shared_dict cert_data 10M",
-			"lua_shared_dict key_data 10M",
 		)
 	}
 

--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -192,6 +192,7 @@ func buildLuaSharedDictionaries(s interface{}, dynamicConfigurationEnabled bool,
 	if dynamicConfigurationEnabled {
 		out = append(out,
 			"lua_shared_dict configuration_data 5M",
+			"lua_shared_dict certificate_data 16M",
 			"lua_shared_dict locks 512k",
 			"lua_shared_dict balancer_ewma 1M",
 			"lua_shared_dict balancer_ewma_last_touched_at 1M",

--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -196,6 +196,8 @@ func buildLuaSharedDictionaries(s interface{}, dynamicConfigurationEnabled bool,
 			"lua_shared_dict balancer_ewma 1M",
 			"lua_shared_dict balancer_ewma_last_touched_at 1M",
 			"lua_shared_dict sticky_sessions 1M",
+			"lua_shared_dict cert_data 10M",
+			"lua_shared_dict key_data 10M",
 		)
 	}
 

--- a/rootfs/etc/nginx/lua/configuration.lua
+++ b/rootfs/etc/nginx/lua/configuration.lua
@@ -56,8 +56,14 @@ local function handle_servers()
   -- Update certificates and private keys for each host
   for _, server in ipairs(servers) do
     if server.hostname and server.sslCert.pemCertKey then
-      local success, err = certificate_data:set(server.hostname, server.sslCert.pemCertKey)
+      local success, err = certificate_data:safe_set(server.hostname, server.sslCert.pemCertKey)
       if not success then
+        if err == "no memory" then
+          ngx.status = ngx.HTTP_INTERNAL_SERVER_ERROR
+          ngx.log(ngx.ERR, "no memory in certificate_data dictionary")
+          return
+        end
+        
         local err_msg = string.format("error setting certificate for %s: %s\n",
           server.hostname, tostring(err))
         table.insert(err_buf, err_msg)

--- a/rootfs/etc/nginx/lua/test/configuration_test.lua
+++ b/rootfs/etc/nginx/lua/test/configuration_test.lua
@@ -1,0 +1,97 @@
+_G._TEST = true
+local cjson = require("cjson")
+
+local _ngx = {
+    shared = {
+        certificate_data = {
+          get = function(self, rsc) end,
+          set = function(self, a) return true end,
+        }
+    },
+    print = function(msg) return msg end,
+    log = function(stream, msg) end,
+    var = {},
+    HTTP_OK = 200,
+    HTTP_BAD_REQUEST = 400,
+    HTTP_CREATED = 201,
+    HTTP_INTERNAL_SERVER_ERROR = 500,
+    ERR = nil,
+    req = {
+        read_body = function() end,
+        get_body_data = function() end,
+        get_body_file = function() end,
+    }
+}
+
+_G.ngx = _ngx
+
+local configuration = require("configuration")
+
+describe("Configuration", function()
+    describe("handle_servers()", function()
+        it("should not accept non POST methods", function()
+            ngx.var.request_method = "GET"
+            
+            local s = spy.on(ngx, "print")
+            assert.has_no.errors(configuration.handle_servers)
+            assert.spy(s).was_called_with("Only POST requests are allowed!")
+            assert.same(ngx.status, ngx.HTTP_BAD_REQUEST)
+        end)
+
+        it("should ignore servers that don't have hostname or pemCertKey set", function()
+            ngx.var.request_method = "POST"
+            local mock_servers = cjson.encode({
+                {
+                    hostname = "hostname",
+                    sslCert = {}
+                },
+                {
+                    sslCert = {
+                        pemCertKey = "pemCertKey"
+                    }
+                }
+            })
+            ngx.req.get_body_data = function() return mock_servers end
+
+            local s = spy.on(ngx, "log")
+            assert.has_no.errors(configuration.handle_servers)
+            assert.spy(s).was_called_with(ngx.WARN, "hostname or pemCertKey are not present")
+            assert.same(ngx.status, ngx.HTTP_CREATED)
+        end)
+
+        it("should successfully update certificates and keys for each host", function()
+            ngx.var.request_method = "POST"
+            local mock_servers = cjson.encode({
+                {
+                    hostname = "hostname",
+                    sslCert = {
+                        pemCertKey = "pemCertKey"
+                    }
+                }
+            })
+            ngx.req.get_body_data = function() return mock_servers end
+
+            assert.has_no.errors(configuration.handle_servers)
+            assert.same(ngx.status, ngx.HTTP_CREATED)
+        end)
+
+        it("should log an err and set status to Internal Server Error when a certificate cannot be set", function()
+            ngx.var.request_method = "POST"
+            _ngx.shared.certificate_data.set = function(self, data) return false, "error" end
+            local mock_servers = cjson.encode({
+                {
+                    hostname = "hostname",
+                    sslCert = {
+                        pemCertKey = "pemCertKey"
+                    }
+                }
+            })
+            ngx.req.get_body_data = function() return mock_servers end
+
+            local s = spy.on(ngx, "log")
+            assert.has_no.errors(configuration.handle_servers)
+            assert.spy(s).was_called_with(ngx.ERR, "error setting certificate for hostname: error\n")
+            assert.same(ngx.status, ngx.HTTP_INTERNAL_SERVER_ERROR)
+        end)
+    end)
+end)

--- a/rootfs/etc/nginx/lua/test/configuration_test.lua
+++ b/rootfs/etc/nginx/lua/test/configuration_test.lua
@@ -1,33 +1,31 @@
 _G._TEST = true
 local cjson = require("cjson")
 
-local _ngx = {
-    shared = {
-        certificate_data = {
-          get = function(self, rsc) end,
-          set = function(self, a) return true end,
-        }
-    },
-    print = function(msg) return msg end,
-    log = function(stream, msg) end,
-    var = {},
-    HTTP_OK = 200,
-    HTTP_BAD_REQUEST = 400,
-    HTTP_CREATED = 201,
-    HTTP_INTERNAL_SERVER_ERROR = 500,
-    ERR = nil,
-    req = {
+function get_mocked_ngx_env()
+    local _ngx = {}
+    setmetatable(_ngx, {__index = _G.ngx})
+
+    _ngx.status = 100
+    _ngx.var = {}
+    _ngx.req = {
         read_body = function() end,
-        get_body_data = function() end,
         get_body_file = function() end,
     }
-}
+    return _ngx
+end
 
-_G.ngx = _ngx
-
+local unmocked_ngx = _G.ngx
 local configuration = require("configuration")
 
 describe("Configuration", function()
+    before_each(function()
+        _G.ngx = get_mocked_ngx_env()
+    end)
+
+    after_each(function()
+        _G.ngx = unmocked_ngx
+    end)
+
     describe("handle_servers()", function()
         it("should not accept non POST methods", function()
             ngx.var.request_method = "GET"
@@ -77,7 +75,7 @@ describe("Configuration", function()
 
         it("should log an err and set status to Internal Server Error when a certificate cannot be set", function()
             ngx.var.request_method = "POST"
-            _ngx.shared.certificate_data.set = function(self, data) return false, "error" end
+            ngx.shared.certificate_data.safe_set = function(self, data) return false, "error" end
             local mock_servers = cjson.encode({
                 {
                     hostname = "hostname",
@@ -91,6 +89,25 @@ describe("Configuration", function()
             local s = spy.on(ngx, "log")
             assert.has_no.errors(configuration.handle_servers)
             assert.spy(s).was_called_with(ngx.ERR, "error setting certificate for hostname: error\n")
+            assert.same(ngx.status, ngx.HTTP_INTERNAL_SERVER_ERROR)
+        end)
+
+        it("should log an err and set status to Internal Server Error when shared dictionary is full", function()
+            ngx.var.request_method = "POST"
+            ngx.shared.certificate_data.safe_set = function(self, data) return false, "no memory" end
+            local mock_servers = cjson.encode({
+                {
+                    hostname = "hostname",
+                    sslCert = {
+                        pemCertKey = "pemCertKey"
+                    }
+                }
+            })
+            ngx.req.get_body_data = function() return mock_servers end
+
+            local s = spy.on(ngx, "log")
+            assert.has_no.errors(configuration.handle_servers)
+            assert.spy(s).was_called_with(ngx.ERR, "no memory in certificate_data dictionary")
             assert.same(ngx.status, ngx.HTTP_INTERNAL_SERVER_ERROR)
         end)
     end)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is a part of adding dynamic certificate serving functionality (https://github.com/Shopify/edgescale/issues/515). This adds a Lua endpoint that stores certificates and keys of a host in a shared dictionary and allows Lua directives to retrieve them.

@Shopify/edgescale