### PR TITLE
remove redundant logging

### DIFF
--- a/rootfs/etc/nginx/lua/monitor.lua
+++ b/rootfs/etc/nginx/lua/monitor.lua
@@ -16,7 +16,6 @@ local function send_response_data(upstream_state, client_state)
         status_class = string.sub(status, 0, 1) .. "xx"
       end
 
-      ngx.log(ngx.INFO, upstream_state.addr[i] )
       statsd.increment('ingress.nginx.upstream.response', 1, {
         status=status,
         status_class=status_class,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
this is to fix errors such as
```
  	 log:	 2018/06/04 18:32:37 [error] 532#532: *2771660 lua entry thread aborted: runtime error: /etc/nginx/lua/monitor.lua:19: bad argument #1 to 'log' (expected table to have __tostring metamethod)
```

another option would be to use `tostring()`, but I don't know why we would wanna have that log entry there.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
