### PR TITLE
Deterministic temp dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ ifeq ($(ARCH),s390x)
     QEMUARCH=s390x
 endif
 
-TEMP_DIR := $(shell mktemp -d)
+TEMP_DIR ?= $(shell mktemp -d)
 
 DOCKERFILE := $(TEMP_DIR)/rootfs/Dockerfile
 


### PR DESCRIPTION
r/ @ElvinEfendi @fmejia97 

Deterministic output path of the nginx-ingress-controller binary is needed to extract the binary as an artifact. 

Context: https://github.com/Shopify/edgescale/issues/386#issuecomment-377935187