### PR TITLE
Dynamic Certificate Serving - Controller

### DIFF
--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -681,6 +681,7 @@ type TemplateConfig struct {
 	ListenPorts                 *ListenPorts
 	PublishService              *apiv1.Service
 	DynamicConfigurationEnabled bool
+	DynamicCertificatesEnabled  bool
 	DisableLua                  bool
 }
 

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -96,6 +96,8 @@ type Configuration struct {
 	DynamicConfigurationEnabled bool
 
 	DisableLua bool
+
+	DynamicCertificatesEnabled bool
 }
 
 // GetPublishService returns the Service used to set the load-balancer status of Ingresses.
@@ -197,7 +199,7 @@ func (n *NGINXController) syncIngress(interface{}) error {
 				// it takes time for NGINX to start listening on the configured ports
 				time.Sleep(1 * time.Second)
 			}
-			err := configureDynamically(pcfg, n.cfg.ListenPorts.Status)
+			err := configureDynamically(pcfg, n.cfg.ListenPorts.Status, n.cfg.DynamicCertificatesEnabled)
 			if err == nil {
 				glog.Infof("Dynamic reconfiguration succeeded.")
 			} else {
@@ -1064,6 +1066,12 @@ func (n *NGINXController) createServers(data []*extensions.Ingress,
 						secrKey, host, err)
 					continue
 				}
+			}
+
+			if n.cfg.DynamicCertificatesEnabled {
+				// useless placeholders: just to shut up NGINX configuration loader errors:
+				cert.PemFileName = defaultPemFileName
+				cert.PemSHA = defaultPemSHA
 			}
 
 			servers[host].SSLCert = *cert

--- a/internal/ingress/controller/store/backend_ssl.go
+++ b/internal/ingress/controller/store/backend_ssl.go
@@ -98,11 +98,18 @@ func (s k8sStore) getPemCertificate(secretName string) (*ingress.SSLCert, error)
 			return nil, fmt.Errorf("key 'tls.key' missing from Secret %q", secretName)
 		}
 
-		// If 'ca.crt' is also present, it will allow this secret to be used in the
-		// 'nginx.ingress.kubernetes.io/auth-tls-secret' annotation
-		sslCert, err = ssl.AddOrUpdateCertAndKey(nsSecName, cert, key, ca, s.filesystem)
-		if err != nil {
-			return nil, err
+		if s.isDynamicCertificatesEnabled {
+			sslCert, err = ssl.CreateSSLCert(nsSecName, cert, key, ca)
+			if err != nil {
+				return nil, fmt.Errorf("unexpected error creating SSL Cert: %v", err)
+			}
+		} else {
+			// If 'ca.crt' is also present, it will allow this secret to be used in the
+			// 'nginx.ingress.kubernetes.io/auth-tls-secret' annotation
+			sslCert, err = ssl.AddOrUpdateCertAndKey(nsSecName, cert, key, ca, s.filesystem)
+			if err != nil {
+				return nil, fmt.Errorf("unexpected error creating pem file: %v", err)
+			}
 		}
 
 		msg := fmt.Sprintf("Configuring Secret %q for TLS encryption (CN: %v)", secretName, sslCert.CN)

--- a/internal/ingress/controller/store/store.go
+++ b/internal/ingress/controller/store/store.go
@@ -212,6 +212,8 @@ type k8sStore struct {
 	mu *sync.Mutex
 
 	defaultSSLCertificate string
+
+	isDynamicCertificatesEnabled bool
 }
 
 // New creates a new object store to be used in the ingress controller
@@ -220,19 +222,21 @@ func New(checkOCSP bool,
 	resyncPeriod time.Duration,
 	client clientset.Interface,
 	fs file.Filesystem,
-	updateCh *channels.RingChannel) Storer {
+	updateCh *channels.RingChannel,
+	isDynamicCertificatesEnabled bool) Storer {
 
 	store := &k8sStore{
-		isOCSPCheckEnabled:    checkOCSP,
-		informers:             &Informer{},
-		listers:               &Lister{},
-		sslStore:              NewSSLCertTracker(),
-		filesystem:            fs,
-		updateCh:              updateCh,
-		backendConfig:         ngx_config.NewDefault(),
-		mu:                    &sync.Mutex{},
-		secretIngressMap:      NewObjectRefMap(),
-		defaultSSLCertificate: defaultSSLCertificate,
+		isOCSPCheckEnabled:           checkOCSP,
+		informers:                    &Informer{},
+		listers:                      &Lister{},
+		sslStore:                     NewSSLCertTracker(),
+		filesystem:                   fs,
+		updateCh:                     updateCh,
+		backendConfig:                ngx_config.NewDefault(),
+		mu:                           &sync.Mutex{},
+		secretIngressMap:             NewObjectRefMap(),
+		defaultSSLCertificate:        defaultSSLCertificate,
+		isDynamicCertificatesEnabled: isDynamicCertificatesEnabled,
 	}
 
 	eventBroadcaster := record.NewBroadcaster()

--- a/internal/ingress/controller/store/store_test.go
+++ b/internal/ingress/controller/store/store_test.go
@@ -68,7 +68,8 @@ func TestStore(t *testing.T) {
 			10*time.Minute,
 			clientSet,
 			fs,
-			updateCh)
+			updateCh,
+			false)
 
 		storer.Run(stopCh)
 
@@ -155,7 +156,8 @@ func TestStore(t *testing.T) {
 			10*time.Minute,
 			clientSet,
 			fs,
-			updateCh)
+			updateCh,
+			false)
 
 		storer.Run(stopCh)
 
@@ -302,7 +304,8 @@ func TestStore(t *testing.T) {
 			10*time.Minute,
 			clientSet,
 			fs,
-			updateCh)
+			updateCh,
+			false)
 
 		storer.Run(stopCh)
 
@@ -390,7 +393,8 @@ func TestStore(t *testing.T) {
 			10*time.Minute,
 			clientSet,
 			fs,
-			updateCh)
+			updateCh,
+			false)
 
 		storer.Run(stopCh)
 
@@ -501,7 +505,8 @@ func TestStore(t *testing.T) {
 			10*time.Minute,
 			clientSet,
 			fs,
-			updateCh)
+			updateCh,
+			false)
 
 		storer.Run(stopCh)
 

--- a/internal/ingress/sslcert.go
+++ b/internal/ingress/sslcert.go
@@ -42,6 +42,8 @@ type SSLCert struct {
 	CN []string `json:"cn"`
 	// ExpiresTime contains the expiration of this SSL certificate in timestamp format
 	ExpireTime time.Time `json:"expires"`
+	// Pem encoded certificate and key concatenated
+	PemCertKey string `json:"pemCertKey"`
 }
 
 // GetObjectKind implements the ObjectKind interface as a noop


### PR DESCRIPTION
What this PR does / why we need it:

This PR is a part of adding dynamic certificate serving functionality (Shopify/edgescale#515). When dynamic configuration mode is on, the controller will JSON encode the certificates and post it to an internal endpoint.

@Shopify/edgescale