### PR TITLE
Add unit tests for sticky lua module

### DIFF
--- a/rootfs/etc/nginx/lua/test/balancer/sticky_test.lua
+++ b/rootfs/etc/nginx/lua/test/balancer/sticky_test.lua
@@ -1,5 +1,3 @@
-package.path = "./rootfs/etc/nginx/lua/?.lua;./rootfs/etc/nginx/lua/test/mocks/?.lua;" .. package.path
-
 local resty_chash = require("resty.chash")
 local sticky = require("balancer.sticky")
 local util = require("util")
@@ -163,7 +161,6 @@ describe("Sticky", function()
 
             it("should return the correct endpoint for the client", function()
                 local cookie = require("resty.cookie")
-                local s = {}
                 cookie.new = function(self) 
                     local return_obj = {
                         get = function(k) return string.reverse(test_backend_endpoint) end,

--- a/rootfs/etc/nginx/lua/test/balancer/sticky_test.lua
+++ b/rootfs/etc/nginx/lua/test/balancer/sticky_test.lua
@@ -1,20 +1,27 @@
 local sticky = require("balancer.sticky")
 local util = require("util")
 
-local _ngx = {
-    log = function(stream, msg) end,
-    var = {},
-}
+function get_mocked_ngx_env()
+    local _ngx = {
+        log = function(stream, msg) end,
+        var = {},
+    }
+    setmetatable(_ngx, {__index = _G.ngx})
+    return _ngx
+end
 
-_G.ngx = _ngx
+_G.ngx = get_mocked_ngx_env()
 
 local function get_test_backend()
     return {
         name = "access-router-production-web-80",
         endpoints = {
-        { address = "10.184.7.40", port = "8080", maxFails = 0, failTimeout = 0 },
+            { address = "10.184.7.40", port = "8080", maxFails = 0, failTimeout = 0 },
         },
-        sessionAffinityConfig = { name = "cookie", cookieSessionAffinity = { name = "test_name", hash = "sha1" } },
+        sessionAffinityConfig = {
+            name = "cookie",
+            cookieSessionAffinity = { name = "test_name", hash = "sha1" }
+        },
     }
 end
 

--- a/rootfs/etc/nginx/lua/test/balancer/sticky_test.lua
+++ b/rootfs/etc/nginx/lua/test/balancer/sticky_test.lua
@@ -1,0 +1,151 @@
+package.path = "./rootfs/etc/nginx/lua/?.lua;./rootfs/etc/nginx/lua/test/mocks/?.lua;" .. package.path
+
+local resty_chash = require("resty.chash")
+local sticky = require("balancer.sticky")
+local util = require("util")
+
+local _ngx = {
+    log = function(stream, msg) end,
+    var = {},
+}
+
+_G.ngx = _ngx
+
+local function get_test_backend()
+    return {
+        name = "access-router-production-web-80",
+        endpoints = {
+        { address = "10.184.7.40", port = "8080", maxFails = 0, failTimeout = 0 },
+        },
+        sessionAffinityConfig = { name = "cookie", cookieSessionAffinity = { name = "test_name", hash = "sha1" } },
+    }
+end
+
+describe("Sticky", function()
+    local test_backend = get_test_backend()
+    local test_backend_endpoint= test_backend.endpoints[1].address .. ":" .. test_backend.endpoints[1].port
+    
+    describe("new(backend)", function()
+        context("when backend specifies cookie name", function()
+            it("should return an instance containing the corresponding cookie name", function()
+                local sticky_balancer_instance = sticky:new(test_backend)
+                local test_backend_cookie_name = test_backend.sessionAffinityConfig.cookieSessionAffinity.name
+                assert.equal(sticky_balancer_instance.cookie_name, test_backend_cookie_name)
+            end)
+        end)
+
+        context("when backend does not specify cookie name", function()
+            it("should return an instance with 'route' as cookie name", function()
+                local temp_backend = util.deepcopy(test_backend)
+                temp_backend.sessionAffinityConfig.cookieSessionAffinity.name = nil
+                local sticky_balancer_instance = sticky:new(temp_backend)
+                local default_cookie_name = "route"
+                assert.equal(sticky_balancer_instance.cookie_name, default_cookie_name)
+            end)
+        end)
+        
+        context("when backend specifies hash function", function()
+            it("should return an instance with the corresponding hash implementation", function()
+                local sticky_balancer_instance = sticky:new(test_backend)
+                local test_backend_hash_fn = test_backend.sessionAffinityConfig.cookieSessionAffinity.hash
+                local test_backend_hash_implementation = util[test_backend_hash_fn .. "_digest"]
+                assert.equal(sticky_balancer_instance.digest_func, test_backend_hash_implementation)
+            end)
+        end)
+
+        context("when backend does not specify hash function", function()
+            it("should return an instance with the default implementation (md5)", function()
+                local temp_backend = util.deepcopy(test_backend)
+                temp_backend.sessionAffinityConfig.cookieSessionAffinity.hash = nil
+                local sticky_balancer_instance = sticky:new(temp_backend)
+                local default_hash_fn = "md5"
+                local default_hash_implementation = util[default_hash_fn .. "_digest"]
+                assert.equal(sticky_balancer_instance.digest_func, default_hash_implementation)
+            end)
+        end)
+    end)
+
+    describe("balance()", function()
+        setup(function()
+            util.sha1_digest = function(msg) return msg, false end -- Don't hash for simplification
+        end)
+
+        teardown(function()
+            package.loaded["util"] = nil
+            util = require("util")
+        end)
+        
+        before_each(function()
+            package.loaded["resty.chash"] = nil
+            resty_chash = require("resty.chash")
+
+            package.loaded["balancer.sticky"] = nil
+            sticky = require("balancer.sticky")
+
+            resty_chash.new = function(self, nodes)
+                return {
+                    find = function(self, key)
+                        -- cookie's value is the unhashed endpoint since we stubbed the hash function
+                        assert.equal(key, test_backend_endpoint)
+                        return test_backend_endpoint
+                    end,
+                    next = function(self, index)
+                        return test_backend_endpoint
+                    end,
+                    npoints = 1
+                }
+            end
+        end)
+
+        context("when client doesn't have a cookie set", function()
+            it("should pick an endpoint for the client", function()
+                local cookie = require("resty.cookie")
+                cookie.new = function(self) 
+                    return { 
+                        get = function(self, n) return false end,
+                        set = function(self, n) return true end
+                    }
+                end
+                local sticky_balancer_instance = sticky:new(test_backend)
+                local s = spy.on(sticky_balancer_instance.instance, "next")
+                assert.has_no.errors(function() sticky_balancer_instance:balance() end)
+                assert.spy(s).was_called()
+            end)
+
+            it("should set a cookie on the client", function() 
+                local cookie = require("resty.cookie")
+                local s = {}
+                cookie.new = function(self) 
+                    local cookie_instance = {
+                        set = function(v) return true, nil end,
+                        get = function(k) end,
+                    }
+                    s = spy.on(cookie_instance, "set")
+                    return cookie_instance, false
+                end
+                local sticky_balancer_instance = sticky:new(get_test_backend())
+                assert.has_no.errors(function() sticky_balancer_instance:balance() end)
+                assert.spy(s).was_called()
+            end)
+        end)
+
+        context("when client has a cookie set", function()
+            it("should not set a cookie", function()
+                local cookie = require("resty.cookie")
+                local s = {}
+                cookie.new = function(self) 
+                    local return_obj = {
+                        set = function(v) return false, nil end,
+                        get = function(k) return test_backend_endpoint end,
+                    }
+                    s = spy.on(return_obj, "set")
+                    return return_obj, false
+                end
+                local sticky_balancer_instance = sticky:new(test_backend)
+                assert.has_no.errors(function() sticky_balancer_instance:balance() end)
+                assert.spy(s).was_not_called()
+            end)
+        end)
+    end)
+end)
+

--- a/rootfs/etc/nginx/lua/test/balancer/sticky_test.lua
+++ b/rootfs/etc/nginx/lua/test/balancer/sticky_test.lua
@@ -1,4 +1,5 @@
 local sticky = require("balancer.sticky")
+local cookie = require("resty.cookie")
 local util = require("util")
 
 function get_mocked_ngx_env()
@@ -71,15 +72,12 @@ describe("Sticky", function()
 
     describe("balance()", function()
         before_each(function()
-
             package.loaded["balancer.sticky"] = nil
             sticky = require("balancer.sticky")
-
         end)
 
         context("when client doesn't have a cookie set", function()
             it("should pick an endpoint for the client", function()
-                local cookie = require("resty.cookie")
                 cookie.new = function(self) 
                     return { 
                         get = function(self, n) return false end,
@@ -94,7 +92,6 @@ describe("Sticky", function()
             end)
 
             it("should set a cookie on the client", function() 
-                local cookie = require("resty.cookie")
                 local s = {}
                 cookie.new = function(self)
                     local test_backend_hash_fn = test_backend.sessionAffinityConfig.cookieSessionAffinity.hash
@@ -127,7 +124,6 @@ describe("Sticky", function()
 
         context("when client has a cookie set", function()
             it("should not set a cookie", function()
-                local cookie = require("resty.cookie")
                 local s = {}
                 cookie.new = function(self) 
                     local return_obj = {
@@ -143,7 +139,6 @@ describe("Sticky", function()
             end)
 
             it("should return the correct endpoint for the client", function()
-                local cookie = require("resty.cookie")
                 cookie.new = function(self) 
                     local return_obj = {
                         get = function(k) return string.reverse(test_backend_endpoint) end,


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds unit tests to `sticky` lua module. We need this because we don't have unit test coverage for this module.

Issue: https://github.com/Shopify/edgescale/issues/435
