### PR TITLE
debug defer_to_timer_phase

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -72,13 +72,6 @@ http {
         else
           balancer = res
         end
-
-        ok, res = pcall(require, "statsd_monitor")
-        if not ok then
-            error("require(statsd_monitor) failed: " .. tostring(res))
-        else
-            statsd_monitor = res
-        end
         {{ end }}
 
         ok, res = pcall(require, "monitor")
@@ -913,7 +906,6 @@ stream {
                 {{ end }}
                 {{ if $all.DynamicConfigurationEnabled}}
                 balancer.log()
-                statsd_monitor.call()
                 {{ end }}
 
                 monitor.call()


### PR DESCRIPTION
**What this PR does / why we need it**:
Since we moved more traffic to ingress-nginx we started seeing significant number of "deferred timer queue full" errors: https://logs.shopify.io/en-US/app/search/search?sid=1532097672.54145_0CA9628A-6FA6-448D-ACDA-4D32967B337B

This is unexpected because the queue size is the same is it is in DC LBs and I don't see any similar error with `sourcetype=nginx_error "deferred timer queue full"`. The only difference is we do diskless logging in DC whereas ingress-nginx writes into STDOUT and STDERR. And looking at the implementation the only time when queue fills up is the time interval a timer created for `flush_queue` and pending to be executed. The timer will start as soon as the current handler yields. So I wonder if it is because of logging to STDOUT that makes the handler to take longer to yield.

Here are some logs with debug statements that shows queueing:
```
2018/07/20 14:30:13 [warn] 195#195: *26755 [lua] defer.lua:41: to_timer_phase(): timer_started is: false while logging request, client: 172.17.0.1, server: traffic-misc.shopifycloud.com, request: "GET / HTTP/1.1", upstream: "http://172.17.0.3:8080/", host: "traffic-misc.shopifycloud.com"
2018/07/20 14:30:13 [warn] 195#195: *26755 [lua] defer.lua:48: to_timer_phase(): timer_started is set to true while logging request, client: 172.17.0.1, server: traffic-misc.shopifycloud.com, request: "GET / HTTP/1.1", upstream: "http://172.17.0.3:8080/", host: "traffic-misc.shopifycloud.com"
2018/07/20 14:30:13 [warn] 195#195: *26759 [lua] defer.lua:41: to_timer_phase(): timer_started is: true while logging request, client: 172.17.0.1, server: traffic-misc.shopifycloud.com, request: "GET / HTTP/1.1", upstream: "http://172.17.0.3:8080/", host: "traffic-misc.shopifycloud.com"
2018/07/20 14:30:13 [error] 195#195: *26763 [lua] defer.lua:36: to_timer_phase(): deferred timer queue full while logging request, client: 172.17.0.1, server: traffic-misc.shopifycloud.com, request: "GET / HTTP/1.1", upstream: "http://172.17.0.3:8080/", host: "traffic-misc.shopifycloud.com"
2018/07/20 14:30:13 [error] 195#195: *26763 [lua] monitor.lua:45: call(): failed to defer send_data to timer phase: deferred timer queue full while logging request, client: 172.17.0.1, server: traffic-misc.shopifycloud.com, request: "GET / HTTP/1.1", upstream: "http://172.17.0.3:8080/", host: "traffic-misc.shopifycloud.com"
2018/07/20 14:30:13 [error] 195#195: *26767 [lua] defer.lua:36: to_timer_phase(): deferred timer queue full while logging request, client: 172.17.0.1, server: traffic-misc.shopifycloud.com, request: "GET / HTTP/1.1", upstream: "http://172.17.0.3:8080/", host: "traffic-misc.shopifycloud.com"
2018/07/20 14:30:13 [error] 195#195: *26767 [lua] monitor.lua:45: call(): failed to defer send_data to timer phase: deferred timer queue full while logging request, client: 172.17.0.1, server: traffic-misc.shopifycloud.com, request: "GET / HTTP/1.1", upstream: "http://172.17.0.3:8080/", host: "traffic-misc.shopifycloud.com"
2018/07/20 14:30:13 [warn] 195#195: *26912 [lua] defer.lua:14: started flush_queue, context: ngx.timer, client: 172.17.0.1, server: 0.0.0.0:80
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

@Shopify/edgescale @csfrancis 