### PR TITLE
bump size of defer timer queue

### DIFF
--- a/rootfs/etc/nginx/lua/util/defer.lua
+++ b/rootfs/etc/nginx/lua/util/defer.lua
@@ -2,7 +2,7 @@ local util = require("util")
 
 local timer_started = false
 local queue = {}
-local MAX_QUEUE_SIZE = 10000
+local MAX_QUEUE_SIZE = 100000
 
 local _M = {}
 
@@ -40,8 +40,7 @@ function _M.to_timer_phase(func, ...)
   if not timer_started then
     local ok, err = ngx.timer.at(0, flush_queue)
     if ok then
-      -- unfortunately this is to deal with tests - when running unit tests, we
-      -- dont actually run the timer, we call the function inline
+      -- this is to make sure we don't create another timer while the one created is pending
       if util.tablelength(queue) > 0 then
         timer_started = true
       end


### PR DESCRIPTION
**What this PR does / why we need it**:
This is to cope with the issue described at https://github.com/Shopify/ingress/pull/84/files. For now I don't have any better idea than just bumping up the queue size.

In the long run though, I'd like to redesign this a bit, my current idea is to have a per worker queue just like we do now, but instead of waiting for a handler to yield in order to run the timer to work off the queue we spin up periodic timer on worker init that runs every 0.5 or so to work off the queue. This way we would not depend on the unpredictable yield time of a handler.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

@Shopify/edgescale 