### PR TITLE
[WIP] Refactor EWMA to not use shared dictionaries

### DIFF
--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -192,8 +192,6 @@ func buildLuaSharedDictionaries(s interface{}, dynamicConfigurationEnabled bool,
 		out = append(out,
 			"lua_shared_dict configuration_data 5M",
 			"lua_shared_dict locks 512k",
-			"lua_shared_dict balancer_ewma 1M",
-			"lua_shared_dict balancer_ewma_last_touched_at 1M",
 			"lua_shared_dict sticky_sessions 1M",
 		)
 	}

--- a/rootfs/etc/nginx/lua/balancer/ewma.lua
+++ b/rootfs/etc/nginx/lua/balancer/ewma.lua
@@ -5,37 +5,16 @@
 --   /finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/PeakEwma.scala
 
 
-local resty_lock = require("resty.lock")
 local util = require("util")
 local split = require("util.split")
 
 local DECAY_TIME = 10 -- this value is in seconds
-local LOCK_KEY = ":ewma_key"
 local PICK_SET_SIZE = 2
 
-local ewma_lock = resty_lock:new("locks", {timeout = 0, exptime = 0.1})
+local balancer_ewma = {}
+local balancer_ewma_last_touched_at = {}
 
 local _M = { name = "ewma" }
-
-local function lock(upstream)
-  local _, err = ewma_lock:lock(upstream .. LOCK_KEY)
-  if err then
-    if err ~= "timeout" then
-      ngx.log(ngx.ERR, string.format("EWMA Balancer failed to lock: %s", tostring(err)))
-    end
-  end
-
-  return err
-end
-
-local function unlock()
-  local ok, err = ewma_lock:unlock()
-  if not ok then
-    ngx.log(ngx.ERR, string.format("EWMA Balancer failed to unlock: %s", tostring(err)))
-  end
-
-  return err
-end
 
 local function decay_ewma(ewma, last_touched_at, rtt, now)
   local td = now - last_touched_at
@@ -47,40 +26,18 @@ local function decay_ewma(ewma, last_touched_at, rtt, now)
 end
 
 local function get_or_update_ewma(upstream, rtt, update)
-  local lock_err = nil
-  if update then
-    lock_err = lock(upstream)
-  end
-  local ewma = ngx.shared.balancer_ewma:get(upstream) or 0
-  if lock_err ~= nil then
-    return ewma, lock_err
-  end
+  local ewma = balancer_ewma[upstream] or 0
 
   local now = ngx.now()
-  local last_touched_at = ngx.shared.balancer_ewma_last_touched_at:get(upstream) or 0
+  local last_touched_at = balancer_ewma_last_touched_at[upstream] or 0
   ewma = decay_ewma(ewma, last_touched_at, rtt, now)
 
   if not update then
     return ewma, nil
   end
 
-  local success, err, forcible = ngx.shared.balancer_ewma_last_touched_at:set(upstream, now)
-  if not success then
-    ngx.log(ngx.WARN, "balancer_ewma_last_touched_at:set failed " .. err)
-  end
-  if forcible then
-    ngx.log(ngx.WARN, "balancer_ewma_last_touched_at:set valid items forcibly overwritten")
-  end
-
-  success, err, forcible = ngx.shared.balancer_ewma:set(upstream, ewma)
-  if not success then
-    ngx.log(ngx.WARN, "balancer_ewma:set failed " .. err)
-  end
-  if forcible then
-    ngx.log(ngx.WARN, "balancer_ewma:set valid items forcibly overwritten")
-  end
-
-  unlock()
+  balancer_ewma_last_touched_at[upstream] = now
+  balancer_ewma[upstream] = ewma
   return ewma, nil
 end
 
@@ -152,8 +109,8 @@ function _M.sync(self, backend)
   self.peers = backend.endpoints
 
   -- TODO: Reset state of EWMA per backend
-  ngx.shared.balancer_ewma:flush_all()
-  ngx.shared.balancer_ewma_last_touched_at:flush_all()
+  balancer_ewma = {}
+  balancer_ewma_last_touched_at = {}
 end
 
 function _M.new(self, backend)

--- a/rootfs/etc/nginx/lua/test/balancer/ewma_test.lua
+++ b/rootfs/etc/nginx/lua/test/balancer/ewma_test.lua
@@ -3,10 +3,6 @@ package.path = "./rootfs/etc/nginx/lua/?.lua;./rootfs/etc/nginx/lua/test/mocks/?
 local util = require("util")
 
 local _ngx = {
-  shared = {
-    balancer_ewma = { flush_all = function() end },
-    balancer_ewma_last_touched_at = { flush_all = function() end }
-  },
   log = function(...) end,
   now = function() return os.time() end,
 }
@@ -39,10 +35,6 @@ describe("Balancer ewma", function()
       local instance = balancer_ewma:new(backend)
       
       local stats = { ["10.184.7.40:8080"] = 0.5, ["10.184.97.100:8080"] = 0.3 }
-      ngx.shared.balancer_ewma.get = function(self, key) return stats[key] end
-      local t = ngx.now()-10
-      ngx.shared.balancer_ewma_last_touched_at.get = function(self, key) return t end
-
 
       local host, port = instance:balance()
       assert.equal("10.184.97.100", host)
@@ -66,13 +58,7 @@ describe("Balancer ewma", function()
         endpoints = { { address = "10.184.7.40", port = "8080", maxFails = 0, failTimeout = 0 } }
       }
 
-      local s1 = spy.on(ngx.shared.balancer_ewma, "flush_all")
-      local s2 = spy.on(ngx.shared.balancer_ewma_last_touched_at, "flush_all")
-
       instance:sync(new_backend)
-
-      assert.spy(s1).was_not_called()
-      assert.spy(s2).was_not_called()
     end)
 
     it("updates endpoints", function()
@@ -91,13 +77,7 @@ describe("Balancer ewma", function()
       local new_backend = util.deepcopy(backend)
       new_backend.endpoints[1].maxFails = 3
 
-      local s1 = spy.on(ngx.shared.balancer_ewma, "flush_all")
-      local s2 = spy.on(ngx.shared.balancer_ewma_last_touched_at, "flush_all")
-
       instance:sync(new_backend)
-
-      assert.spy(s1).was_called()
-      assert.spy(s2).was_called()
     end)
   end)
 end)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR refactors EWMA load balancing to not use shared dictionaries. This improves performance (CPU usage) since we would not be using any locks.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

https://github.com/Shopify/edgescale/issues/489

@Shopify/edgescale 