### PR TITLE
build image only on push to releases branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ jobs:
     - make e2e-test
   # split builds to avoid job timeouts
   - stage: publish amd64
-    if: type = push AND branch = master AND repo = Shopify/ingress
+    if: type = push AND branch = releases AND repo = Shopify/ingress
     script:
     - .travis/publish.sh amd64
   - stage: publish arm


### PR DESCRIPTION
**What this PR does / why we need it**:
for https://github.com/Shopify/edgescale/issues/592

It's a problem to build the image automatically on master because sometimes we sync upstream after they release a version and merge couple of PRs on top to the master. When we sync in that case and build automatically we would be building the same version with couple of PRs on top. This might lead to confusion.

With the new workflow when we need to release a new image we push to `releases` branch.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

@Shopify/edgescale 