### PR TITLE
Add e2e test for rewrite-target annotation kube-lego failure

### DIFF
--- a/test/e2e/annotations/rewrite.go
+++ b/test/e2e/annotations/rewrite.go
@@ -121,7 +121,7 @@ var _ = framework.IngressNginxDescribe("Annotations - Rewrite", func() {
 	It("should use correct longest path match", func() {
 		host := "rewrite.bar.com"
 		annotations := map[string]string{}
-		rewrite_annotations := map[string]string{
+		rewriteAnnotations := map[string]string{
 			"nginx.ingress.kubernetes.io/rewrite-target":     "/new/backend",
 			"nginx.ingress.kubernetes.io/enable-rewrite-log": "true",
 		}
@@ -133,9 +133,9 @@ var _ = framework.IngressNginxDescribe("Annotations - Rewrite", func() {
 		Expect(ing).NotTo(BeNil())
 
 		err = f.WaitForNginxServer(host,
-		func(server string) bool {
-			return strings.Contains(server, "/.well-known/acme/challenge")
-		})
+			func(server string) bool {
+				return strings.Contains(server, "/.well-known/acme/challenge")
+			})
 		Expect(err).NotTo(HaveOccurred())
 
 		By("making a request to the non-rewritten location")
@@ -143,7 +143,7 @@ var _ = framework.IngressNginxDescribe("Annotations - Rewrite", func() {
 			Get(f.IngressController.HTTPURL+"/.well-known/acme/challenge").
 			Set("Host", host).
 			End()
-		
+
 		Expect(len(errs)).Should(Equal(0))
 		Expect(resp.StatusCode).Should(Equal(http.StatusOK))
 
@@ -153,8 +153,8 @@ var _ = framework.IngressNginxDescribe("Annotations - Rewrite", func() {
 		Expect(logs).ToNot(ContainSubstring(`rewritten data: "/new/backend/.well-known/acme/challenge", args: "",`))
 
 		By(`creating an ingress definition with the rewrite-target annotation set on the "/" location`)
-		rewrite_ing := framework.NewSingleIngress("rewrite-index", "/", host, f.IngressController.Namespace, "http-svc", 80, &rewrite_annotations)
-		_, err = f.EnsureIngress(rewrite_ing)
+		rewriteIng := framework.NewSingleIngress("rewrite-index", "/", host, f.IngressController.Namespace, "http-svc", 80, &rewriteAnnotations)
+		_, err = f.EnsureIngress(rewriteIng)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ing).NotTo(BeNil())
 
@@ -169,7 +169,7 @@ var _ = framework.IngressNginxDescribe("Annotations - Rewrite", func() {
 			Get(f.IngressController.HTTPURL+"/.well-known/acme/challenge").
 			Set("Host", host).
 			End()
-	
+
 		Expect(len(errs)).Should(Equal(0))
 		Expect(resp.StatusCode).Should(Equal(http.StatusOK))
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This PR adds and e2e-test for the edge case that currently breaks kube-lego. This issue causes requests to the path `/.well-known/acme/challenge` to be redirected to the `/` path when the rewrite-target annotation is set for the index route.

This annotation enforces the use of the `~*` location modifier. In NGINX, regex paths take priority over regular prefixes unless the `=` or `^~` location modifiers are used. 

**Which issue this PR fixes** : 
Partially fixes https://github.com/Shopify/edgescale/issues/659

**Special notes for your reviewer**:
Currently this test **will fail**. Additional changes need to be made to prevent this issue from occurring. 

**Relevant links:**
- [Ingress-Nginx Regex Support Project Brief](https://docs.google.com/document/d/1bb23mByl8TELMpcWLs_Cp30-ehKL-rblPO9weLch7NA/edit?ts=5b929287#heading=h.ypkmjgl9xesn)
- [Spreadsheet of regex support for ingress controllers](https://docs.google.com/spreadsheets/d/1-oS8CKD4MtdEMar7QMUibCb-TUJ5ZIglRl2cLvaQ5zs/edit#gid=0)
- [Discussion of standardizing regex support among ingress controllers](kubernetes/ingress-nginx#555)
- [Open issue on lack of regex support in ingress-nginx](https://github.com/kubernetes/ingress-nginx/pull/1415)
- [NGINX location modifiers](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/api/extensions/v1beta1/types.go#L703 )
