### PR TITLE
enabe back statsd monitor

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -98,6 +98,13 @@ http {
           certificate = res
         end
         {{ end }}
+
+        ok, res = pcall(require, "statsd_monitor")
+        if not ok then
+          error("require(statsd_monitor) failed: " .. tostring(res))
+        else
+          statsd_monitor = res
+        end
     }
 
     init_worker_by_lua_block {
@@ -945,6 +952,7 @@ stream {
                 {{ end }}
                 balancer.log()
                 monitor.call()
+                statsd_monitor.call()
             }
 
             {{ if (and (not (empty $server.SSLCert.PemFileName)) $all.Cfg.HSTS) }}


### PR DESCRIPTION
I don't know how and when but our statsd monitor introduced at https://github.com/Shopify/ingress/pull/53 (also see https://github.com/Shopify/ingress/pull/59/files) is not being used anymore. This configures it.

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:


@Shopify/edgescale 