### PR TITLE
Prevent X-Forwarded-Proto forward during external auth subrequest

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -858,6 +858,7 @@ stream {
 
             proxy_pass_request_body     off;
             proxy_set_header            Content-Length "";
+            proxy_set_header            X-Fowarded-Proto "";
 
             {{ if $location.ExternalAuth.Method }}
             proxy_method                {{ $location.ExternalAuth.Method }};


### PR DESCRIPTION
**What this PR does / why we need it**:
This prevent `X-Forwarded-Proto` forwarding during external auth sub request.

This cause external auth to return 308 or 301 even if its target url is an hardcoded `https`.

**Which issue this PR fixes**
fixes https://github.com/kubernetes/ingress-nginx/issues/3389

**Special notes for your reviewer**:

@Shopify/edgescale 