### PR TITLE
Fix X-Forwarded-Proto typo

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -856,7 +856,7 @@ stream {
 
             proxy_pass_request_body     off;
             proxy_set_header            Content-Length "";
-            proxy_set_header            X-Fowarded-Proto "";
+            proxy_set_header            X-Forwarded-Proto "";
 
             {{ if $location.ExternalAuth.Method }}
             proxy_method                {{ $location.ExternalAuth.Method }};


### PR DESCRIPTION
Once again, sync upstream

@Shopify/edgescale 