### PR TITLE
disable default monitoring

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -85,13 +85,6 @@ http {
           balancer = res
         end
 
-        ok, res = pcall(require, "monitor")
-        if not ok then
-          error("require failed: " .. tostring(res))
-        else
-          monitor = res
-        end
-
         {{ if $all.DynamicCertificatesEnabled }}
         ok, res = pcall(require, "certificate")
         if not ok then
@@ -112,7 +105,6 @@ http {
     init_worker_by_lua_block {
         defer_to_timer.init_worker()
         balancer.init_worker()
-        monitor.init_worker()
     }
 
     {{/* Enable the real_ip module only if we use either X-Forwarded headers or Proxy Protocol. */}}
@@ -836,7 +828,6 @@ stream {
 
             proxy_pass            http://upstream_balancer;
             log_by_lua_block {
-                monitor.call()
             }
         }
         {{ end }}
@@ -1102,7 +1093,6 @@ stream {
                 waf:exec()
                 {{ end }}
                 balancer.log()
-                monitor.call()
                 statsd_monitor.call()
             }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We don't use any stats from default monitoring. And we know that it's causing the controller to use a lot of resource: https://github.com/kubernetes/ingress-nginx/issues/3314

This PR disables that.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

@Shopify/edgescale 