### PR TITLE
restrict push builds to master only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,10 @@ env:
   - E2E_NODES=6
   - GH_REF=github.com/kubernetes/ingress-nginx
 
+branches:
+  only:
+  - master
+
 jobs:
   include:
   - stage: Static Check


### PR DESCRIPTION
**What this PR does / why we need it**:

To avoid double builds in PRs I had builds on pull requests disabled in the below dashboard. That resulted us not running e2e tests. Now I enabled both back and found another way (this PR) to avoid double builds per PR.
<img width="846" alt="screen shot 2018-12-13 at 3 37 10 pm" src="https://user-images.githubusercontent.com/1150042/49936288-f9b62180-feec-11e8-8e2c-2b3420dc63cb.png">

The PR makes sure build on push will be triggered on master only.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

@Shopify/edgescale 