### PR TITLE
Force canary mode base on Ingress names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ jobs:
     - make e2e-test
   # split builds to avoid job timeouts
   - stage: publish amd64
-    if: type = push AND branch = releases AND repo = Shopify/ingress AND env(COMPONENT) = "ingress-controller"
+    if: type = push AND branch = canary-guard AND repo = Shopify/ingress AND env(COMPONENT) = "ingress-controller"
     script:
     - .travis/publish.sh amd64
   - stage: publish arm

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@
 all: all-container
 
 # Use the 0.0 tag for testing, it shouldn't clobber any release builds
-TAG ?= 0.21.0
+TAG ?= 0.22.0-rc5-canary-guard
 REGISTRY ?= quay.io/kubernetes-ingress-controller
 DOCKER ?= docker
 SED_I ?= sed -i

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -564,7 +564,7 @@ func (n *NGINXController) getBackendServers(ingresses []*ingress.Ingress) ([]*in
 		}
 
 		// set aside canary ingresses to merge later
-		if anns.Canary.Enabled {
+		if isCanary(ing) {
 			canaryIngresses = append(canaryIngresses, ing)
 		}
 	}
@@ -683,7 +683,7 @@ func (n *NGINXController) createUpstreams(data []*ingress.Ingress, du *ingress.B
 			}
 
 			// configure traffic shaping for canary
-			if anns.Canary.Enabled {
+			if isCanary(ing) {
 				upstreams[defBackend].NoServer = true
 				upstreams[defBackend].TrafficShapingPolicy = ingress.TrafficShapingPolicy{
 					Weight: anns.Canary.Weight,
@@ -748,7 +748,7 @@ func (n *NGINXController) createUpstreams(data []*ingress.Ingress, du *ingress.B
 				}
 
 				// configure traffic shaping for canary
-				if anns.Canary.Enabled {
+				if isCanary(ing) {
 					upstreams[name].NoServer = true
 					upstreams[name].TrafficShapingPolicy = ingress.TrafficShapingPolicy{
 						Weight: anns.Canary.Weight,
@@ -948,7 +948,7 @@ func (n *NGINXController) createServers(data []*ingress.Ingress,
 		// default upstream name
 		un := du.Name
 
-		if anns.Canary.Enabled {
+		if isCanary(ing) {
 			klog.V(2).Infof("Ingress %v is marked as Canary, ignoring", ingKey)
 			continue
 		}
@@ -1029,7 +1029,7 @@ func (n *NGINXController) createServers(data []*ingress.Ingress,
 		ingKey := k8s.MetaNamespaceKey(ing)
 		anns := ing.ParsedAnnotations
 
-		if anns.Canary.Enabled {
+		if isCanary(ing) {
 			klog.V(2).Infof("Ingress %v is marked as Canary, ignoring", ingKey)
 			continue
 		}
@@ -1330,4 +1330,19 @@ func getRemovedIngresses(rucfg, newcfg *ingress.Configuration) []string {
 	}
 
 	return oldIngresses.Difference(newIngresses).List()
+}
+
+// isCanary returns whether an Ingress has the canary annotation
+// or contains 'canary' in its name.
+func isCanary(ing *ingress.Ingress) bool {
+	if ing.ParsedAnnotations.Canary.Enabled {
+		return true
+	}
+
+	if strings.Contains(ing.Name, "canary") {
+		klog.Warning("Canary ingress %v/%v does not have canary annotation set to true.", ing.GetNamespace(), ing.GetName())
+		return true
+	}
+
+	return false
 }

--- a/internal/ingress/controller/controller_test.go
+++ b/internal/ingress/controller/controller_test.go
@@ -939,3 +939,71 @@ func fakeX509Cert(dnsNames []string) *x509.Certificate {
 		},
 	}
 }
+
+func TestIsCanary(t *testing.T) {
+	testCases := []struct {
+		ing    *ingress.Ingress
+		canary bool
+	}{
+		{
+			ing: &ingress.Ingress{
+				Ingress: extensions.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "example-canary-1",
+					},
+				},
+				ParsedAnnotations: &annotations.Ingress{
+					Canary: canary.Config{
+						Enabled: true,
+					},
+				},
+			},
+			canary: true,
+		},
+		{
+			ing: &ingress.Ingress{
+				Ingress: extensions.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "example-1",
+					},
+				},
+				ParsedAnnotations: &annotations.Ingress{},
+			},
+			canary: false,
+		},
+		{
+			ing: &ingress.Ingress{
+				Ingress: extensions.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "example-2",
+					},
+				},
+				ParsedAnnotations: &annotations.Ingress{
+					Canary: canary.Config{
+						Enabled: true,
+					},
+				},
+			},
+			canary: true,
+		},
+
+		{
+			ing: &ingress.Ingress{
+				Ingress: extensions.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "example-canary-2",
+					},
+				},
+				ParsedAnnotations: &annotations.Ingress{},
+			},
+			canary: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		res := isCanary(testCase.ing)
+		if res != testCase.canary {
+			t.Errorf("bad isCanary result for %s, expected %v, got %v", testCase.ing.Name, testCase.canary, res)
+		}
+	}
+}


### PR DESCRIPTION
This replaces https://github.com/Shopify/ingress/pull/183

For https://github.com/Shopify/edgescale/issues/820

**What this PR does / why we need it**:

It enforces the canary mode on an Ingress if it contains `canary` in its name.

**Which issue this PR fixes**:

**Special notes for your reviewer**:

@Shopify/edgescale 
