### PR TITLE
Enable build on releases branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ env:
 branches:
   only:
   - master
+  - releases
 
 jobs:
   include:


### PR DESCRIPTION
Since https://github.com/Shopify/ingress/pull/186 push to releases branch doesn't trigger a build.

@Shopify/edgescale 