### PR TITLE
release on master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ jobs:
     - make e2e-test
   # split builds to avoid job timeouts
   - stage: publish amd64
-    if: type = push AND branch = releases AND repo = Shopify/ingress AND env(COMPONENT) = "ingress-controller"
+    if: type = push AND branch = master AND repo = Shopify/ingress AND env(COMPONENT) = "ingress-controller"
     script:
     - .travis/publish.sh amd64
   - stage: publish arm


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently we release new versions from `releases` branch. That was probably done to make releases either by skipping CI etc. It just an extra step to use releases `branch`. I suggest the following workflow:
1. Create a new branch and update TAG in Makefile with the version you'd like to release and make a PR
2. Once PR is approved merge it to master then CI will automatically build and publish the new image.

This way we will see what commits are included in what version by looking at commit history of `master` branch. The downside is we will have to wait for e2e tests to run for both PR at step 1 and as well as on `master` before the release.

We have protection in publish script where when a new commit is merged to master that does not change TAG in Makefile it will skip the build and release process.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

@Shopify/edgescale 