### PR TITLE
Release 0.22.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@
 all: all-container
 
 # Use the 0.0 tag for testing, it shouldn't clobber any release builds
-TAG ?= 0.21.0
+TAG ?= 0.22.0
 REGISTRY ?= quay.io/kubernetes-ingress-controller
 DOCKER ?= docker
 SED_I ?= sed -i


### PR DESCRIPTION
I've updated the tag in the Makefile to 0.22.0.

https://github.com/Shopify/edgescale/issues/859
@Shopify/edgescale 