### PR TITLE
Add scheme to statsd_monitor ingress.nginx.client.response metric

### DIFF
--- a/rootfs/etc/nginx/lua/statsd_monitor.lua
+++ b/rootfs/etc/nginx/lua/statsd_monitor.lua
@@ -33,7 +33,8 @@ local function send_response_data(upstream_state, client_state)
   statsd.increment('ingress.nginx.client.response', 1, {
     status=client_state.status,
     status_class=status_class,
-    upstream_name=client_state.upstream_name
+    upstream_name=client_state.upstream_name,
+    scheme=client_state.scheme
   })
 
   statsd.histogram('ingress.nginx.client.request_time', client_state.request_time, {
@@ -64,7 +65,8 @@ function _M.call()
     }, {
       status=ngx.var.status,
       request_time=ngx.var.request_time,
-      upstream_name=ngx.var.proxy_upstream_name
+      upstream_name=ngx.var.proxy_upstream_name,
+      scheme=ngx.var.pass_access_scheme
     })
 
   if err then


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds the scheme to `ingress.nginx.client.response` metric.

If `use-forwarded-headers` is enabled, the forwarded scheme will be used.

**Special notes for your reviewer**:

@Shopify/edgescale 