### PR TITLE
environment specific default statsd tags and better alignment with datadog agent

### DIFF
--- a/rootfs/etc/nginx/lua/plugins/statsd_monitor/main.lua
+++ b/rootfs/etc/nginx/lua/plugins/statsd_monitor/main.lua
@@ -16,13 +16,13 @@ local function send_response_data(upstream_state, client_state)
         status_class = string.sub(status, 0, 1) .. "xx"
       end
 
-      statsd.increment('ingress.nginx.upstream.response', 1, {
+      statsd.increment('nginx.upstream.response', 1, {
         status=status,
         status_class=status_class,
         upstream_name=client_state.upstream_name
       })
 
-      statsd.histogram('ingress.nginx.upstream.response_time',
+      statsd.histogram('nginx.upstream.response_time',
         upstream_state.response_time[i], {
           upstream_name=client_state.upstream_name
       })
@@ -30,13 +30,13 @@ local function send_response_data(upstream_state, client_state)
   end
 
   status_class = string.sub(client_state.status, 0, 1) .. "xx"
-  statsd.increment('ingress.nginx.client.response', 1, {
+  statsd.increment('nginx.client.response', 1, {
     status=client_state.status,
     status_class=status_class,
     upstream_name=client_state.upstream_name
   })
 
-  statsd.histogram('ingress.nginx.client.request_time', client_state.request_time, {
+  statsd.histogram('nginx.client.request_time', client_state.request_time, {
     upstream_name=client_state.upstream_name
   })
 end


### PR DESCRIPTION
Datadog checkers tag the metrics they emit with `kube_namespace`, but we have been tagging the custom metrics emitted from code using `namespace`. The PR 

* fixes that inconsistency by tagging using `kube_namespace` in the code.
* adds `deploy_stage` tag to every metric. While this has no use at the moment it will be useful if/when we have canary deploys.
* remove `ingress.` prefix from metrics to make them consistent with nginx-routing-modules

@Shopify/edgescale 