### PR TITLE
share ewma stats among workers

### DIFF
--- a/build/test-lua.sh
+++ b/build/test-lua.sh
@@ -26,4 +26,5 @@ resty \
   --shdict "certificate_data 16M" \
   --shdict "balancer_ewma 1M" \
   --shdict "balancer_ewma_last_touched_at 1M" \
+  --shdict "balancer_ewma_locks 512k" \
   ./rootfs/etc/nginx/lua/test/run.lua ${BUSTED_ARGS} ./rootfs/etc/nginx/lua/test/ ./rootfs/etc/nginx/lua/plugins/**/test

--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -213,6 +213,9 @@ func buildLuaSharedDictionaries(s interface{}, disableLuaRestyWAF bool) string {
 	out := []string{
 		"lua_shared_dict configuration_data 5M",
 		"lua_shared_dict certificate_data 16M",
+		"lua_shared_dict balancer_ewma 5M",
+		"lua_shared_dict balancer_ewma_last_touched_at 5M",
+		"lua_shared_dict balancer_ewma_locks 512k",
 	}
 
 	if !disableLuaRestyWAF {

--- a/rootfs/etc/nginx/lua/test/balancer/ewma_test.lua
+++ b/rootfs/etc/nginx/lua/test/balancer/ewma_test.lua
@@ -16,8 +16,8 @@ describe("Balancer ewma", function()
       local instance = balancer_ewma:new(backend)
 
       instance:after_balance()
-      assert.equal(0.27, instance.ewma[ngx.var.upstream_addr])
-      assert.equal(ngx_now, instance.ewma_last_touched_at[ngx.var.upstream_addr])
+      assert.equal(0.27, ngx.shared.balancer_ewma:get(ngx.var.upstream_addr))
+      assert.equal(ngx_now, ngx.shared.balancer_ewma_last_touched_at:get(ngx.var.upstream_addr))
     end)
   end)
 

--- a/test/e2e/framework/exec.go
+++ b/test/e2e/framework/exec.go
@@ -18,6 +18,7 @@ package framework
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os/exec"
@@ -27,6 +28,30 @@ import (
 
 	"k8s.io/api/core/v1"
 )
+
+// GetLbAlgorithm returns algorithm identifier for the given backend
+func (f *Framework) GetLbAlgorithm(serviceName string, servicePort int) (string, error) {
+	backendName := fmt.Sprintf("%s-%s-%v", f.Namespace, serviceName, servicePort)
+	cmd := fmt.Sprintf("/dbg backends get %s", backendName)
+
+	output, err := f.ExecIngressPod(cmd)
+	if err != nil {
+		return "", err
+	}
+
+	var backend map[string]interface{}
+	err = json.Unmarshal([]byte(output), &backend)
+	if err != nil {
+		return "", err
+	}
+
+	algorithm, ok := backend["load-balance"].(string)
+	if !ok {
+		return "", fmt.Errorf("error while accessing load-balance field of backend")
+	}
+
+	return algorithm, nil
+}
 
 // ExecIngressPod executes a command inside the first container in ingress controller running pod
 func (f *Framework) ExecIngressPod(command string) (string, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:

This is  revert of https://github.com/kubernetes/ingress-nginx/pull/3295. Additionally the PR also adds an e2e test for EWMA and a guard to error when resty lock can not be instantiated.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
