### PR TITLE
do not flush all ewma stats during syncs

### DIFF
--- a/rootfs/etc/nginx/lua/balancer/ewma.lua
+++ b/rootfs/etc/nginx/lua/balancer/ewma.lua
@@ -169,7 +169,9 @@ function _M.sync(self, backend)
 
   -- Calculate slow start EWMA
   local slow_start_ewma = 0
-  for _, ewma in pairs(self.ewma) do
+  for _, endpoint in pairs(self.peers) do
+    local endpoint_string = endpoint.address .. ":" .. endpoint.port
+    local ewma = get_or_update_ewma(endpoint_string, 0, false)
     if slow_start_ewma < ewma then
       slow_start_ewma = ewma
     end

--- a/rootfs/etc/nginx/lua/balancer/ewma.lua
+++ b/rootfs/etc/nginx/lua/balancer/ewma.lua
@@ -49,6 +49,24 @@ local function decay_ewma(ewma, last_touched_at, rtt, now)
   return ewma
 end
 
+local function store_stats(upstream, ewma, now)
+  local success, err, forcible = ngx.shared.balancer_ewma_last_touched_at:set(upstream, now)
+  if not success then
+    ngx.log(ngx.WARN, "balancer_ewma_last_touched_at:set failed " .. err)
+  end
+  if forcible then
+    ngx.log(ngx.WARN, "balancer_ewma_last_touched_at:set valid items forcibly overwritten")
+  end
+
+  success, err, forcible = ngx.shared.balancer_ewma:set(upstream, ewma)
+  if not success then
+    ngx.log(ngx.WARN, "balancer_ewma:set failed " .. err)
+  end
+  if forcible then
+    ngx.log(ngx.WARN, "balancer_ewma:set valid items forcibly overwritten")
+  end
+end
+
 local function get_or_update_ewma(upstream, rtt, update)
   local lock_err = nil
   if update then
@@ -67,21 +85,7 @@ local function get_or_update_ewma(upstream, rtt, update)
     return ewma, nil
   end
 
-  local success, err, forcible = ngx.shared.balancer_ewma_last_touched_at:set(upstream, now)
-  if not success then
-    ngx.log(ngx.WARN, "balancer_ewma_last_touched_at:set failed " .. err)
-  end
-  if forcible then
-    ngx.log(ngx.WARN, "balancer_ewma_last_touched_at:set valid items forcibly overwritten")
-  end
-
-  success, err, forcible = ngx.shared.balancer_ewma:set(upstream, ewma)
-  if not success then
-    ngx.log(ngx.WARN, "balancer_ewma:set failed " .. err)
-  end
-  if forcible then
-    ngx.log(ngx.WARN, "balancer_ewma:set valid items forcibly overwritten")
-  end
+  store_stats(upstream, ewma, now)
 
   unlock()
 
@@ -150,9 +154,6 @@ function _M.after_balance(_)
 end
 
 function _M.sync(self, backend)
-  self.traffic_shaping_policy = backend.trafficShapingPolicy
-  self.alternative_backends = backend.alternativeBackends
-
   local normalized_endpoints_added, normalized_endpoints_removed = util.diff_endpoints(self.peers, backend.endpoints)
 
   if #normalized_endpoints_added == 0 and #normalized_endpoints_removed == 0 then
@@ -160,6 +161,8 @@ function _M.sync(self, backend)
     return
   end
 
+  self.traffic_shaping_policy = backend.trafficShapingPolicy
+  self.alternative_backends = backend.alternativeBackends
   self.peers = backend.endpoints
 
   for _, endpoint_string in ipairs(normalized_endpoints_removed) do
@@ -168,19 +171,21 @@ function _M.sync(self, backend)
   end
 
   -- Calculate slow start EWMA
-  local slow_start_ewma = 0
+  local total_ewma = 0
+  local endpoints_count = 0
   for _, endpoint in pairs(self.peers) do
     local endpoint_string = endpoint.address .. ":" .. endpoint.port
-    local ewma = get_or_update_ewma(endpoint_string, 0, false)
-    if slow_start_ewma < ewma then
-      slow_start_ewma = ewma
+    local ewma = ngx.shared.balancer_ewma:get(endpoint_string)
+    if ewma then
+      endpoints_count = endpoints_count + 1
+      total_ewma = total_ewma + ewma
     end
   end
+  local slow_start_ewma = total_ewma / endpoints_count
 
   local now = ngx.now()
   for _, endpoint_string in ipairs(normalized_endpoints_added) do
-    ngx.shared.balancer_ewma:set(endpoint_string)
-    ngx.shared.balancer_ewma_last_touched_at:set(now)
+    store_stats(endpoint_string, slow_start_ewma, now)
   end
 end
 

--- a/rootfs/etc/nginx/lua/test/balancer/ewma_test.lua
+++ b/rootfs/etc/nginx/lua/test/balancer/ewma_test.lua
@@ -1,12 +1,30 @@
 local util = require("util")
 
+local original_ngx = ngx
+local function reset_ngx()
+  _G.ngx = original_ngx
+end
+
+local function mock_ngx(mock)
+  local _ngx = mock
+  setmetatable(_ngx, { __index = ngx })
+  _G.ngx = _ngx
+end
+
 describe("Balancer ewma", function()
   local balancer_ewma = require("balancer.ewma")
+  local ngx_now = 1543238266
+
+  before_each(function()
+    mock_ngx({ now = function() return ngx_now end })
+  end)
+
+  after_each(function()
+    reset_ngx()
+  end)
 
   describe("after_balance()", function()
-    local ngx_now = 1543238266
-    _G.ngx.now = function() return ngx_now end
-    _G.ngx.var = { upstream_response_time = "0.25", upstream_connect_time = "0.02", upstream_addr = "10.184.7.40:8080" }
+    mock_ngx({ var = { upstream_response_time = "0.25", upstream_connect_time = "0.02", upstream_addr = "10.184.7.40:8080" } })
 
     it("updates EWMA stats", function()
       local backend = {
@@ -52,40 +70,61 @@ describe("Balancer ewma", function()
 
   describe("sync()", function()
     local backend, instance
+    local store_ewma_stats = function(endpoint_string, ewma, touched_at)
+      ngx.shared.balancer_ewma:set(endpoint_string, ewma)
+      ngx.shared.balancer_ewma_last_touched_at:set(endpoint_string, touched_at)
+    end
+    local assert_ewma_stats = function(endpoint_string, ewma, touched_at)
+      assert.are.equals(ewma, ngx.shared.balancer_ewma:get(endpoint_string))
+      assert.are.equals(touched_at, ngx.shared.balancer_ewma_last_touched_at:get(endpoint_string))
+    end
 
-    before_each(function()
-      backend = {
-        name = "my-dummy-backend", ["load-balance"] = "ewma",
-        endpoints = { { address = "10.184.7.40", port = "8080", maxFails = 0, failTimeout = 0 } }
+    backend = {
+      name = "namespace-service-port", ["load-balance"] = "ewma",
+      endpoints = {
+        { address = "10.10.10.1", port = "8080", maxFails = 0, failTimeout = 0 },
+        { address = "10.10.10.2", port = "8080", maxFails = 0, failTimeout = 0 },
+        { address = "10.10.10.3", port = "8080", maxFails = 0, failTimeout = 0 },
       }
-      instance = balancer_ewma:new(backend)
-    end)
+    }
+    store_ewma_stats("10.10.10.1:8080", 0.2, 1543238266)
+    store_ewma_stats("10.10.10.2:8080", 0.3, 1543238269)
+    store_ewma_stats("10.10.10.3:8080", 1.2, 1543238226)
 
-    it("does nothing when endpoints do not change", function()
-      local new_backend = {
-        endpoints = { { address = "10.184.7.40", port = "8080", maxFails = 0, failTimeout = 0 } }
-      }
+    instance = balancer_ewma:new(backend)
 
-      instance:sync(new_backend)
-    end)
-
-    it("updates endpoints", function()
-      local new_backend = {
-        endpoints = {
-          { address = "10.184.7.40", port = "8080", maxFails = 0, failTimeout = 0 },
-          { address = "10.184.97.100", port = "8080", maxFails = 0, failTimeout = 0 },
-        }
-      }
-
-      instance:sync(new_backend)
-      assert.are.same(new_backend.endpoints, instance.peers)
-    end)
-
-    it("resets stats", function()
+    it("does not reset stats when endpoints do not change", function()
       local new_backend = util.deepcopy(backend)
-      new_backend.endpoints[1].maxFails = 3
 
       instance:sync(new_backend)
+
+      assert.are.same(new_backend.endpoints, instance.peers)
+
+      assert_ewma_stats("10.10.10.1:8080", 0.2, 1543238266)
+      assert_ewma_stats("10.10.10.2:8080", 0.3, 1543238269)
+      assert_ewma_stats("10.10.10.3:8080", 1.2, 1543238226)
+    end)
+
+    it("updates peers, deletes stats for old endpoints and sets average ewma score to new ones", function()
+      local new_backend = util.deepcopy(backend)
+
+      -- existing endpoint 10.10.10.2 got deleted
+      -- and replaced with 11.10.10.2
+      new_backend.endpoints[2].address = "10.10.10.4"
+      -- and there's one new extra endpoint
+      table.insert(new_backend.endpoints, { address = "10.10.10.5", port = "8080", maxFails = 0, failTimeout = 0 })
+
+      instance:sync(new_backend)
+
+      assert.are.same(new_backend.endpoints, instance.peers)
+
+      assert_ewma_stats("10.10.10.1:8080", 0.2, 1543238266)
+      assert_ewma_stats("10.10.10.2:8080", nil, nil)
+      assert_ewma_stats("10.10.10.3:8080", 1.2, 1543238226)
+
+      local slow_start_ewma = (0.2 + 1.2) / 2
+      assert_ewma_stats("10.10.10.4:8080", slow_start_ewma, ngx_now)
+      assert_ewma_stats("10.10.10.5:8080", slow_start_ewma, ngx_now)
     end)
   end)
 end)

--- a/rootfs/etc/nginx/lua/test/util_test.lua
+++ b/rootfs/etc/nginx/lua/test/util_test.lua
@@ -12,24 +12,87 @@ end
 describe("lua_ngx_var", function()
   local util = require("util")
 
-  before_each(function()
-    mock_ngx({ var = { remote_addr = "192.168.1.1", [1] = "nginx/regexp/1/group/capturing" } })
-  end)
-
   after_each(function()
     reset_ngx()
-    package.loaded["monitor"] = nil
   end)
 
-  it("returns value of nginx var by key", function()
-    assert.equal("192.168.1.1", util.lua_ngx_var("$remote_addr"))
+  describe("lua_ngx_var", function()
+    before_each(function()
+      mock_ngx({ var = { remote_addr = "192.168.1.1", [1] = "nginx/regexp/1/group/capturing" } })
+    end)
+
+    it("returns value of nginx var by key", function()
+      assert.equal("192.168.1.1", util.lua_ngx_var("$remote_addr"))
+    end)
+
+    it("returns value of nginx var when key is number", function()
+      assert.equal("nginx/regexp/1/group/capturing", util.lua_ngx_var("$1"))
+    end)
+
+    it("returns nil when variable is not defined", function()
+      assert.equal(nil, util.lua_ngx_var("$foo_bar"))
+    end)
   end)
 
-  it("returns value of nginx var when key is number", function()
-    assert.equal("nginx/regexp/1/group/capturing", util.lua_ngx_var("$1"))
-  end)
+  describe("diff_endpoints", function()
+    it("returns removed and added endpoints", function()
+      local old = {
+        { address = "10.10.10.1", port = "8080" },
+        { address = "10.10.10.2", port = "8080" },
+        { address = "10.10.10.3", port = "8080" },
+      }
+      local new = {
+        { address = "10.10.10.1", port = "8080" },
+        { address = "10.10.10.2", port = "8081" },
+        { address = "11.10.10.2", port = "8080" },
+        { address = "11.10.10.3", port = "8080" },
+      }
+      local expected_added = { "10.10.10.2:8081", "11.10.10.2:8080", "11.10.10.3:8080" }
+      table.sort(expected_added)
+      local expected_removed = { "10.10.10.2:8080", "10.10.10.3:8080" }
+      table.sort(expected_removed)
 
-  it("returns nil when variable is not defined", function()
-    assert.equal(nil, util.lua_ngx_var("$foo_bar"))
+      local added, removed = util.diff_endpoints(old, new)
+      table.sort(added)
+      table.sort(removed)
+
+      assert.are.same(expected_added, added)
+      assert.are.same(expected_removed, removed)
+    end)
+
+    it("returns empty results for empty inputs", function()
+      local added, removed = util.diff_endpoints({}, {})
+
+      assert.are.same({}, added)
+      assert.are.same({}, removed)
+    end)
+
+    it("returns empty results for same inputs", function()
+      local old = {
+        { address = "10.10.10.1", port = "8080" },
+        { address = "10.10.10.2", port = "8080" },
+        { address = "10.10.10.3", port = "8080" },
+      }
+      local new = util.deepcopy(old)
+
+      local added, removed = util.diff_endpoints(old, new)
+
+      assert.are.same({}, added)
+      assert.are.same({}, removed)
+    end)
+
+    it("handles endpoints with nil attribute", function()
+      local old = {
+        { address = nil, port = "8080" },
+        { address = "10.10.10.2", port = "8080" },
+        { address = "10.10.10.3", port = "8080" },
+      }
+      local new = util.deepcopy(old)
+      new[2].port = nil
+
+      local added, removed = util.diff_endpoints(old, new)
+      assert.are.same({ "10.10.10.2:nil" }, added)
+      assert.are.same({ "10.10.10.2:8080" }, removed)
+    end)
   end)
 end)

--- a/rootfs/etc/nginx/lua/util.lua
+++ b/rootfs/etc/nginx/lua/util.lua
@@ -1,5 +1,6 @@
 local string_len = string.len
 local string_sub = string.sub
+local string_format = string.format
 
 local _M = {}
 
@@ -33,7 +34,7 @@ local function normalize_endpoints(endpoints)
   local normalized_endpoints = {}
 
   for _, endpoint in pairs(endpoints) do
-    local endpoint_string = endpoint.address .. ":" .. endpoint.port
+    local endpoint_string = string_format("%s:%s", endpoint.address, endpoint.port)
     normalized_endpoints[endpoint_string] = true
   end
 
@@ -44,6 +45,7 @@ end
 -- and as a first argument returns what endpoints are in new
 -- but are not in old, and as a second argument it returns
 -- what endpoints are in old but are in new.
+-- Both return values are normalized (ip:port).
 function _M.diff_endpoints(old, new)
   local endpoints_added, endpoints_removed = {}, {}
   local normalized_old, normalized_new = normalize_endpoints(old), normalize_endpoints(new)

--- a/rootfs/etc/nginx/lua/util.lua
+++ b/rootfs/etc/nginx/lua/util.lua
@@ -26,6 +26,43 @@ function _M.lua_ngx_var(ngx_var)
   return ngx.var[var_name]
 end
 
+-- normalize_endpoints takes endpoints as an array of endpoint objects
+-- and returns a table where keys are string that's endpoint.address .. ":" .. endpoint.port
+-- and values are all true
+local function normalize_endpoints(endpoints)
+  local normalized_endpoints = {}
+
+  for _, endpoint in pairs(endpoints) do
+    local endpoint_string = endpoint.address .. ":" .. endpoint.port
+    normalized_endpoints[endpoint_string] = true
+  end
+
+  return normalized_endpoints
+end
+
+-- diff_endpoints compares old and new
+-- and as a first argument returns what endpoints are in new
+-- but are not in old, and as a second argument it returns
+-- what endpoints are in old but are in new.
+function _M.diff_endpoints(old, new)
+  local endpoints_added, endpoints_removed = {}, {}
+  local normalized_old, normalized_new = normalize_endpoints(old), normalize_endpoints(new)
+
+  for endpoint_string, _ in pairs(normalized_old) do
+    if not normalized_new[endpoint_string] then
+      table.insert(endpoints_removed, endpoint_string)
+    end
+  end
+
+  for endpoint_string, _ in pairs(normalized_new) do
+    if not normalized_old[endpoint_string] then
+      table.insert(endpoints_added, endpoint_string)
+    end
+  end
+
+  return endpoints_added, endpoints_removed
+end
+
 -- this implementation is taken from
 -- https://web.archive.org/web/20131225070434/http://snippets.luacode.org/snippets/Deep_Comparison_of_Two_Values_3
 -- and modified for use in this project


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR makes sure we don't forget all the existing EWMA stats for the endpoints that do not change during sync. It only deletes stats for the endpoints that are no longer exist. The PR also sets seed EWMA value for new endpoints based on the average of existing EWMA values.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
