### PR TITLE
Ewma refactoring and introducing $balancer_ewma_score

### DIFF
--- a/rootfs/etc/nginx/lua/test/balancer/ewma_test.lua
+++ b/rootfs/etc/nginx/lua/test/balancer/ewma_test.lua
@@ -11,73 +11,29 @@ local function mock_ngx(mock)
   _G.ngx = _ngx
 end
 
+local function flush_all_ewma_stats()
+  ngx.shared.balancer_ewma:flush_all()
+  ngx.shared.balancer_ewma_last_touched_at:flush_all()
+end
+
+local function store_ewma_stats(endpoint_string, ewma, touched_at)
+  ngx.shared.balancer_ewma:set(endpoint_string, ewma)
+  ngx.shared.balancer_ewma_last_touched_at:set(endpoint_string, touched_at)
+end
+
+local function assert_ewma_stats(endpoint_string, ewma, touched_at)
+  assert.are.equals(ewma, ngx.shared.balancer_ewma:get(endpoint_string))
+  assert.are.equals(touched_at, ngx.shared.balancer_ewma_last_touched_at:get(endpoint_string))
+end
+
+
 describe("Balancer ewma", function()
   local balancer_ewma = require("balancer.ewma")
   local ngx_now = 1543238266
+  local backend, instance
 
   before_each(function()
-    mock_ngx({ now = function() return ngx_now end })
-  end)
-
-  after_each(function()
-    reset_ngx()
-  end)
-
-  describe("after_balance()", function()
-    mock_ngx({ var = { upstream_response_time = "0.25", upstream_connect_time = "0.02", upstream_addr = "10.184.7.40:8080" } })
-
-    it("updates EWMA stats", function()
-      local backend = {
-        name = "my-dummy-backend", ["load-balance"] = "ewma",
-        endpoints = { { address = "10.184.7.40", port = "8080", maxFails = 0, failTimeout = 0 } }
-      }
-      local instance = balancer_ewma:new(backend)
-
-      instance:after_balance()
-      assert.equal(0.27, ngx.shared.balancer_ewma:get(ngx.var.upstream_addr))
-      assert.equal(ngx_now, ngx.shared.balancer_ewma_last_touched_at:get(ngx.var.upstream_addr))
-    end)
-  end)
-
-  describe("balance()", function()
-    it("returns single endpoint when the given backend has only one endpoint", function()
-      local backend = {
-        name = "my-dummy-backend", ["load-balance"] = "ewma",
-        endpoints = { { address = "10.184.7.40", port = "8080", maxFails = 0, failTimeout = 0 } }
-      }
-      local instance = balancer_ewma:new(backend)
-
-      local peer = instance:balance()
-      assert.equal("10.184.7.40:8080", peer)
-    end)
-
-    it("picks the endpoint with lowest score when there two of them", function()
-      local backend = {
-        name = "my-dummy-backend", ["load-balance"] = "ewma",
-        endpoints = {
-          { address = "10.184.7.40", port = "8080", maxFails = 0, failTimeout = 0 },
-          { address = "10.184.97.100", port = "8080", maxFails = 0, failTimeout = 0 },
-        }
-      }
-      local instance = balancer_ewma:new(backend)
-      instance.ewma =  { ["10.184.7.40:8080"] = 0.5, ["10.184.97.100:8080"] = 0.3 }
-      instance.ewma_last_touched_at =  { ["10.184.7.40:8080"] = ngx.now(), ["10.184.97.100:8080"] = ngx.now() }
-
-      local peer = instance:balance()
-      assert.equal("10.184.97.100:8080", peer)
-    end)
-  end)
-
-  describe("sync()", function()
-    local backend, instance
-    local store_ewma_stats = function(endpoint_string, ewma, touched_at)
-      ngx.shared.balancer_ewma:set(endpoint_string, ewma)
-      ngx.shared.balancer_ewma_last_touched_at:set(endpoint_string, touched_at)
-    end
-    local assert_ewma_stats = function(endpoint_string, ewma, touched_at)
-      assert.are.equals(ewma, ngx.shared.balancer_ewma:get(endpoint_string))
-      assert.are.equals(touched_at, ngx.shared.balancer_ewma_last_touched_at:get(endpoint_string))
-    end
+    mock_ngx({ now = function() return ngx_now end, var = {} })
 
     backend = {
       name = "namespace-service-port", ["load-balance"] = "ewma",
@@ -87,12 +43,58 @@ describe("Balancer ewma", function()
         { address = "10.10.10.3", port = "8080", maxFails = 0, failTimeout = 0 },
       }
     }
-    store_ewma_stats("10.10.10.1:8080", 0.2, 1543238266)
-    store_ewma_stats("10.10.10.2:8080", 0.3, 1543238269)
-    store_ewma_stats("10.10.10.3:8080", 1.2, 1543238226)
+    store_ewma_stats("10.10.10.1:8080", 0.2, ngx_now - 1)
+    store_ewma_stats("10.10.10.2:8080", 0.3, ngx_now - 5)
+    store_ewma_stats("10.10.10.3:8080", 1.2, ngx_now - 100)
 
     instance = balancer_ewma:new(backend)
+  end)
 
+  after_each(function()
+    reset_ngx()
+    flush_all_ewma_stats()
+  end)
+
+  describe("after_balance()", function()
+    it("updates EWMA stats", function()
+      ngx.var = { upstream_addr = "10.10.10.2:8080", upstream_connect_time = "0.02", upstream_response_time = "0.1" }
+
+      instance:after_balance()
+
+      local weight = math.exp(-5 / 10)
+      local expected_ewma = 0.3 * weight + 0.12 * (1.0 - weight)
+
+      assert.are.equals(expected_ewma, ngx.shared.balancer_ewma:get(ngx.var.upstream_addr))
+      assert.are.equals(ngx_now, ngx.shared.balancer_ewma_last_touched_at:get(ngx.var.upstream_addr))
+    end)
+  end)
+
+  describe("balance()", function()
+    it("returns single endpoint when the given backend has only one endpoint", function()
+      local single_endpoint_backend = util.deepcopy(backend)
+      table.remove(single_endpoint_backend.endpoints, 3)
+      table.remove(single_endpoint_backend.endpoints, 2)
+      local single_endpoint_instance = balancer_ewma:new(single_endpoint_backend)
+
+      local peer = single_endpoint_instance:balance()
+
+      assert.are.equals("10.10.10.1:8080", peer)
+    end)
+
+    it("picks the endpoint with lowest decayed score", function()
+      local two_endpoints_backend = util.deepcopy(backend)
+      table.remove(two_endpoints_backend.endpoints, 2)
+      local two_endpoints_instance = balancer_ewma:new(two_endpoints_backend)
+
+      local peer = two_endpoints_instance:balance()
+
+      -- even though 10.10.10.1:8080 has a lower ewma score
+      -- algorithm picks 10.10.10.3:8080 because its decayed score is even lower
+      assert.equal("10.10.10.3:8080", peer)
+    end)
+  end)
+
+  describe("sync()", function()
     it("does not reset stats when endpoints do not change", function()
       local new_backend = util.deepcopy(backend)
 
@@ -100,16 +102,16 @@ describe("Balancer ewma", function()
 
       assert.are.same(new_backend.endpoints, instance.peers)
 
-      assert_ewma_stats("10.10.10.1:8080", 0.2, 1543238266)
-      assert_ewma_stats("10.10.10.2:8080", 0.3, 1543238269)
-      assert_ewma_stats("10.10.10.3:8080", 1.2, 1543238226)
+      assert_ewma_stats("10.10.10.1:8080", 0.2, ngx_now - 1)
+      assert_ewma_stats("10.10.10.2:8080", 0.3, ngx_now - 5)
+      assert_ewma_stats("10.10.10.3:8080", 1.2, ngx_now - 100)
     end)
 
     it("updates peers, deletes stats for old endpoints and sets average ewma score to new ones", function()
       local new_backend = util.deepcopy(backend)
 
       -- existing endpoint 10.10.10.2 got deleted
-      -- and replaced with 11.10.10.2
+      -- and replaced with 10.10.10.4
       new_backend.endpoints[2].address = "10.10.10.4"
       -- and there's one new extra endpoint
       table.insert(new_backend.endpoints, { address = "10.10.10.5", port = "8080", maxFails = 0, failTimeout = 0 })
@@ -118,9 +120,9 @@ describe("Balancer ewma", function()
 
       assert.are.same(new_backend.endpoints, instance.peers)
 
-      assert_ewma_stats("10.10.10.1:8080", 0.2, 1543238266)
+      assert_ewma_stats("10.10.10.1:8080", 0.2, ngx_now - 1)
       assert_ewma_stats("10.10.10.2:8080", nil, nil)
-      assert_ewma_stats("10.10.10.3:8080", 1.2, 1543238226)
+      assert_ewma_stats("10.10.10.3:8080", 1.2, ngx_now - 100)
 
       local slow_start_ewma = (0.2 + 1.2) / 2
       assert_ewma_stats("10.10.10.4:8080", slow_start_ewma, ngx_now)

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -1091,6 +1091,7 @@ stream {
 
             port_in_redirect {{ if $location.UsePortInRedirects }}on{{ else }}off{{ end }};
 
+            set $balancer_ewma_score -1;
             set $proxy_upstream_name    "{{ buildUpstreamName $location }}";
             set $proxy_host             $proxy_upstream_name;
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Cleanup after https://github.com/Shopify/ingress/pull/221 and introduction of `$balancer_ewma_score` variable. The variable is set to the score of the picked upstream for current request. By including this var in access log we can have better monitoring of EWMA algorithm.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
