### PR TITLE
do not save nan value

### DIFF
--- a/rootfs/etc/nginx/lua/balancer/ewma.lua
+++ b/rootfs/etc/nginx/lua/balancer/ewma.lua
@@ -147,6 +147,11 @@ local function calculate_slow_start_ewma(self)
     end
   end
 
+  if endpoints_count == 0 then
+    ngx.log(ngx.INFO, "no ewma value exists for the endpoints")
+    return nil
+  end
+
   return total_ewma / endpoints_count
 end
 
@@ -199,9 +204,11 @@ function _M.sync(self, backend)
   end
 
   local slow_start_ewma = calculate_slow_start_ewma(self)
-  local now = ngx.now()
-  for _, endpoint_string in ipairs(normalized_endpoints_added) do
-    store_stats(endpoint_string, slow_start_ewma, now)
+  if slow_start_ewma ~= nil then
+    local now = ngx.now()
+    for _, endpoint_string in ipairs(normalized_endpoints_added) do
+      store_stats(endpoint_string, slow_start_ewma, now)
+    end
   end
 end
 


### PR DESCRIPTION
**What this PR does / why we need it**:
When ingress-nginx pod start it gets list of endpoints incrementally. With the first batch it initializes the algorithm but until it proxied any request to the endpoints and received response, it won't have any EWMA score for them. So if during that time new batch of endpoints update comes, it'll try to calculate average ewma value but since no ewma exist it will return `0/0` which is `nan`.

This PR fixes that scenario by returning `nil`, and ignoring slow start setting. What will happen is when calculating score, we will default to 0. This will be fine because every endpoint will have no score, hence 0.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
