### PR TITLE
Remove incorrect nginx prefix in CORS rules

### DIFF
--- a/docs/user-guide/nginx-configuration/annotations.md
+++ b/docs/user-guide/nginx-configuration/annotations.md
@@ -260,38 +260,38 @@ This service will be handle the response when the service in the Ingress rule do
 ### Enable CORS
 
 To enable Cross-Origin Resource Sharing (CORS) in an Ingress rule, add the annotation
-`nginx.ingress.kubernetes.io/enable-cors: "true"`. This will add a section in the server
+`ingress.kubernetes.io/enable-cors: "true"`. This will add a section in the server
 location enabling this functionality.
 
 CORS can be controlled with the following annotations:
 
-* `nginx.ingress.kubernetes.io/cors-allow-methods`
+* `ingress.kubernetes.io/cors-allow-methods`
   controls which methods are accepted. This is a multi-valued field, separated by ',' and
   accepts only letters (upper and lower case).
   - Default: `GET, PUT, POST, DELETE, PATCH, OPTIONS`
-  - Example: `nginx.ingress.kubernetes.io/cors-allow-methods: "PUT, GET, POST, OPTIONS"`
+  - Example: `ingress.kubernetes.io/cors-allow-methods: "PUT, GET, POST, OPTIONS"`
 
-* `nginx.ingress.kubernetes.io/cors-allow-headers`
+* `ingress.kubernetes.io/cors-allow-headers`
   controls which headers are accepted. This is a multi-valued field, separated by ',' and accepts letters,
   numbers, _ and -.
   - Default: `DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization`
-  - Example: `nginx.ingress.kubernetes.io/cors-allow-headers: "X-Forwarded-For, X-app123-XPTO"`
+  - Example: `ingress.kubernetes.io/cors-allow-headers: "X-Forwarded-For, X-app123-XPTO"`
 
-* `nginx.ingress.kubernetes.io/cors-allow-origin`
+* `ingress.kubernetes.io/cors-allow-origin`
   controls what's the accepted Origin for CORS.
   This is a single field value, with the following format: `http(s)://origin-site.com` or `http(s)://origin-site.com:port`
   - Default: `*`
-  - Example: `nginx.ingress.kubernetes.io/cors-allow-origin: "https://origin-site.com:4443"`
+  - Example: `ingress.kubernetes.io/cors-allow-origin: "https://origin-site.com:4443"`
 
-* `nginx.ingress.kubernetes.io/cors-allow-credentials`
+* `ingress.kubernetes.io/cors-allow-credentials`
   controls if credentials can be passed during CORS operations.
   - Default: `true`
-  - Example: `nginx.ingress.kubernetes.io/cors-allow-credentials: "false"`
+  - Example: `ingress.kubernetes.io/cors-allow-credentials: "false"`
 
-* `nginx.ingress.kubernetes.io/cors-max-age`
+* `ingress.kubernetes.io/cors-max-age`
   controls how long preflight requests can be cached.
   Default: `1728000`
-  Example: `nginx.ingress.kubernetes.io/cors-max-age: 600`
+  Example: `ingress.kubernetes.io/cors-max-age: 600`
 
 !!! note
     For more information please see [https://enable-cors.org](https://enable-cors.org/server_nginx.html) 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
The `nginx.` prefix in the CORS rules causes them not to function. Removing the prefix enabled the rules to function correctly - see https://github.com/Shopify/ProjectZRT/blob/master/config/deploy/production/web.yml.erb#L37-L40 for an example. I can't speak to the other rules on this page, perhaps @anthonyho007 is more knowledgeable as he helped identify this issue for my own project?

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
No Issue / I can't see the issues on this repo

**Special notes for your reviewer**:
I am open to explaining anything needed, hope I didn't miss any information you needed.This is not my technical area of expertise, however I did come across this last week in my own Project ZRT and this was the fix that worked :)

### Pings 
@anthonyho007 as he helped diagnose the problem
